### PR TITLE
Remove asyncio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ requires-python = ">=3.7"
 dependencies = [
     "aiohttp>=3.8",
     "arrow>=1.2",
-    "asyncio>=3.4.3",
 ]
 
 [project.urls]


### PR DESCRIPTION
Python 3.4 introduced the `asyncio` library. `pyproject.toml` says [>=3.7](https://github.com/tronikos/opower/blob/main/pyproject.toml#L10), thus `asyncio` is not needed. 