### PR TITLE
Create subclasses for the two Evergy subdomains

### DIFF
--- a/src/opower/utilities/base.py
+++ b/src/opower/utilities/base.py
@@ -12,7 +12,8 @@ class UtilityBase:
     def __init_subclass__(cls, **kwargs) -> None:
         """Keep track of all subclass implementations."""
         super().__init_subclass__(**kwargs)
-        cls.subclasses.append(cls)
+        if not cls.__name__.startswith("_"):
+            cls.subclasses.append(cls)
 
     @staticmethod
     def name() -> str:

--- a/src/opower/utilities/evergy.py
+++ b/src/opower/utilities/evergy.py
@@ -23,18 +23,13 @@ class EvergyLoginParser(HTMLParser):
             self.verification_token = token
 
 
-class Evergy(UtilityBase):
+class __EvergyBase(UtilityBase):
     """Evergy."""
 
     @staticmethod
     def name() -> str:
         """Distinct recognizable name of the utility."""
         return "Evergy"
-
-    @staticmethod
-    def subdomain() -> str:
-        """Return the opower.com subdomain for this utility."""
-        return "kcpk"
 
     @staticmethod
     def timezone() -> str:
@@ -90,3 +85,16 @@ class Evergy(UtilityBase):
             assert opower_access_token, "Failed to parse OPower bearer token"
 
         session.headers.add("authorization", f"{opower_access_token}")
+
+
+class EvergyKS(__EvergyBase):
+    @staticmethod
+    def subdomain() -> str:
+        """Return the opower.com subdomain for this utility."""
+        return "kcpk"
+    
+class EvergyMO(__EvergyBase):
+    @staticmethod
+    def subdomain() -> str:
+        """Return the opower.com subdomain for this utility."""
+        return "kcpl"


### PR DESCRIPTION
It looks like Evergy uses `kcpk` for customers in Kansas and `kcpl` for customers in Missouri.

First commit does a bit of refactoring to separate them into `EvergyKS` and `EvergyMO` subclasses of a new `__EvergyBase` parent class. Second commit hides `__evergybase` as an option from demo.py:

```
$ python src/demo.py --error-out-please
usage: demo.py [-h] [--utility {atlanticcityelectric,bge,comed,delmarva,evergyks,evergymo,peco,pepco,pge,pse}] [--username USERNAME] [--password PASSWORD]
               [--aggregate_type {bill,day,hour}] [--start_date START_DATE] [--end_date END_DATE] [--usage_only] [-v]
demo.py: error: unrecognized arguments: --error-out-please
```

Demo  output:

```
$   python src/demo.py --utility evergymo --verbose
Username: [snip]
Password: 
DEBUG:/home/mark/sauce/opower/src/opower/opower.py:Fetching: https://kcpl.opower.com/ei/edge/apis/multi-account-v1/cws/kcpl/customers?offset=0&batchSize=100&addressFilter=
DEBUG:/home/mark/sauce/opower/src/opower/opower.py:Fetching: https://kcpl.opower.com/ei/edge/apis/bill-forecast-cws-v1/cws/kcpl/customers/[snip]/combined-forecast

Data for meter: ELEC

Current bill forecast: Forecast(account=Account(customer=Customer(uuid='[snip]'), uuid='[snip]', utility_account_id='[snip]', meter_type=<MeterType.ELEC: 'ELEC'>), start_date=datetime.date(2023, 6, 27), end_date=datetime.date(2023, 7, 26), current_date=datetime.date(2023, 7, 22), unit_of_measure=<UnitOfMeasure.KWH: 'KWH'>, usage_to_date=702.0, cost_to_date=84.0, forecasted_usage=898.0, forecasted_cost=104.0, typical_usage=1073.0, typical_cost=170.0)

Getting historical data: aggregate_type= day start_date= 2023-07-15 18:51:57.167671 end_date= 2023-07-22 18:51:57.167690
DEBUG:/home/mark/sauce/opower/src/opower/opower.py:Fetching: https://kcpl.opower.com/ei/edge/apis/DataBrowser-v1/cws/cost/utilityAccount/[snip]?aggregateType=day&startDate=2023-07-15T00%3A00%3A00-05%3A00&endDate=2023-07-23T00%3A00%3A00-05%3A00
start_time      end_time        consumption     provided_cost   start_minus_prev_end    end_minus_prev_end
2023-07-15 00:00:00-05:00       2023-07-16 00:00:00-05:00       42.879  3.13693458      None    None
2023-07-16 00:00:00-05:00       2023-07-17 00:00:00-05:00       35.7294 2.3988471       0:00:00 1 day, 0:00:00
2023-07-17 00:00:00-05:00       2023-07-18 00:00:00-05:00       41.2188 4.201165002     0:00:00 1 day, 0:00:00
2023-07-18 00:00:00-05:00       2023-07-19 00:00:00-05:00       34.947  3.771765972     0:00:00 1 day, 0:00:00
2023-07-19 00:00:00-05:00       2023-07-20 00:00:00-05:00       40.86   3.956948856     0:00:00 1 day, 0:00:00
2023-07-20 00:00:00-05:00       2023-07-21 00:00:00-05:00       45.2022 4.341655362     0:00:00 1 day, 0:00:00
2023-07-21 00:00:00-05:00       2023-07-22 00:00:00-05:00       40.1844 3.66580365      0:00:00 1 day, 0:00:00
```