### PR TITLE
Add implementation for conEdison

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">=3.7"
 dependencies = [
     "aiohttp>=3.8",
     "arrow>=1.2",
+    "pyotp>=2.0",
 ]
 
 [project.urls]

--- a/src/demo.py
+++ b/src/demo.py
@@ -13,7 +13,8 @@ from opower import AggregateType, Opower, get_supported_utilities
 
 async def _main():
     supported_utilities = [
-        utility.__name__.lower() for utility in get_supported_utilities()
+        utility.__name__.lower()
+        for utility in get_supported_utilities(supports_mfa=True)
     ]
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -31,6 +32,10 @@ async def _main():
         "--password",
         help="Password for logging into the utility's website. "
         "If not provided, you will be asked for it",
+    )
+    parser.add_argument(
+        "--mfa_secret",
+        help="MFA secret for logging into the utility's website.",
     )
     parser.add_argument(
         "--aggregate_type",
@@ -68,7 +73,7 @@ async def _main():
     password = args.password or getpass("Password: ")
 
     async with aiohttp.ClientSession() as session:
-        opower = Opower(session, utility, username, password)
+        opower = Opower(session, utility, username, password, args.mfa_secret)
         await opower.async_login()
         # Re-login to make sure code handles already logged in sessions.
         await opower.async_login()

--- a/src/opower/opower.py
+++ b/src/opower/opower.py
@@ -5,7 +5,7 @@ from datetime import date, datetime
 from enum import Enum
 import json
 import logging
-from typing import Any
+from typing import Any, Optional
 from urllib.parse import urlencode
 
 import aiohttp
@@ -108,14 +108,22 @@ class UsageRead:
     consumption: float  # taken from consumption.value field, in KWH or THERM
 
 
-def get_supported_utilities() -> list[type["UtilityBase"]]:
+def get_supported_utilities(supports_mfa=False) -> list[type["UtilityBase"]]:
     """Return a list of all supported utilities."""
-    return UtilityBase.subclasses
+    return [
+        cls for cls in UtilityBase.subclasses if supports_mfa or not cls.accepts_mfa()
+    ]
 
 
-def get_supported_utility_names() -> list[str]:
+def get_supported_utility_names(supports_mfa=False) -> list[str]:
     """Return a sorted list of names of all supported utilities."""
-    return sorted([utility.name() for utility in UtilityBase.subclasses])
+    return sorted(
+        [
+            utility.name()
+            for utility in UtilityBase.subclasses
+            if supports_mfa or not utility.accepts_mfa()
+        ]
+    )
 
 
 def _select_utility(name: str) -> type[UtilityBase]:
@@ -130,7 +138,12 @@ class Opower:
     """Class that can get historical and forecasted usage/cost from an utility."""
 
     def __init__(
-        self, session: aiohttp.ClientSession, utility: str, username: str, password: str
+        self,
+        session: aiohttp.ClientSession,
+        utility: str,
+        username: str,
+        password: str,
+        optional_mfa_secret: Optional[str] = None,
     ) -> None:
         """Initialize."""
         # Note: Do not modify default headers since Home Assistant that uses this library needs to use
@@ -139,6 +152,7 @@ class Opower:
         self.utility: type[UtilityBase] = _select_utility(utility)
         self.username = username
         self.password = password
+        self.optional_mfa_secret = optional_mfa_secret
         self.access_token = None
         self.customers = []
 
@@ -150,8 +164,9 @@ class Opower:
         """
         try:
             self.access_token = await self.utility.async_login(
-                self.session, self.username, self.password
+                self.session, self.username, self.password, self.optional_mfa_secret
             )
+
         except ClientResponseError as err:
             if err.status in (401, 403):
                 raise InvalidAuth(err)

--- a/src/opower/utilities/base.py
+++ b/src/opower/utilities/base.py
@@ -1,6 +1,8 @@
 """Base class that each utility needs to extend."""
 
 
+from typing import Optional
+
 import aiohttp
 
 
@@ -33,8 +35,16 @@ class UtilityBase:
         raise NotImplementedError
 
     @staticmethod
+    def accepts_mfa() -> str:
+        """Check if Utility implementations supports MFA."""
+        return False
+
+    @staticmethod
     async def async_login(
-        session: aiohttp.ClientSession, username: str, password: str
+        session: aiohttp.ClientSession,
+        username: str,
+        password: str,
+        optional_mfa_secret: Optional[str],
     ) -> str | None:
         """Login to the utility website and authorize opower.
 

--- a/src/opower/utilities/coned.py
+++ b/src/opower/utilities/coned.py
@@ -1,0 +1,119 @@
+"""condEdison (ConEd)."""
+
+from typing import Optional
+
+import aiohttp
+from pyotp import TOTP
+
+from ..const import USER_AGENT
+from ..exceptions import InvalidAuth
+from .base import UtilityBase
+
+LOGIN_BASE = "https://www.coned.com/sitecore/api/ssc/ConEdWeb-Foundation-Login-Areas-LoginAPI/User/0"
+LOGIN_HEADERS = {
+    "User-Agent": USER_AGENT,
+    "Referer": "https://www.coned.com/",
+}
+RETURN_URL = "/en/accounts-billing/my-account/energy-use"
+
+
+class ConEd(UtilityBase):
+    """conEdison (ConEd)."""
+
+    @staticmethod
+    def name() -> str:
+        """Distinct recognizable name of the utility."""
+        return "conEdison (ConEd)"
+
+    @staticmethod
+    def subdomain() -> str:
+        """Return the opower.com subdomain for this utility."""
+        return "cned"
+
+    @staticmethod
+    def timezone() -> str:
+        """Return the timezone."""
+        return "America/New_York"
+
+    @staticmethod
+    def accepts_mfa() -> str:
+        """Check if Utility implementations supports MFA."""
+        return True
+
+    @staticmethod
+    async def async_login(
+        session: aiohttp.ClientSession,
+        username: str,
+        password: str,
+        optional_mfa_secret: Optional[str],
+    ) -> None:
+        """Login to the utility website."""
+        # Double-logins are somewhat broken if cookies stay around.
+        # Let's clear everything except device tokens (which allow skipping 2FA)
+        session.cookie_jar.clear(
+            lambda cookie: cookie["domain"] == "www.coned.com"
+            and cookie.key != "CE_DEVICE_ID"
+        )
+
+        async with session.post(
+            LOGIN_BASE + "/Login",
+            json={
+                "LoginEmail": username,
+                "LoginPassword": password,
+                "LoginRememberMe": False,
+                "ReturnUrl": RETURN_URL,
+                "OpenIdRelayState": "",
+            },
+            headers=LOGIN_HEADERS,
+            raise_for_status=True,
+        ) as resp:
+            result = await resp.json()
+            if not result["login"]:
+                raise InvalidAuth("Username/Password are invalid")
+
+            redirectUrl = None
+            if "authRedirectUrl" in result:
+                redirectUrl = result["authRedirectUrl"]
+            else:
+                if result["newDevice"]:
+                    if not result["noMfa"] and not optional_mfa_secret:
+                        raise InvalidAuth("TOTP secret is required for MFA accounts")
+
+                    if not result["noMfa"]:
+                        mfaCode = TOTP(optional_mfa_secret).now()
+
+                        async with session.post(
+                            LOGIN_BASE + "/VerifyFactor",
+                            headers=LOGIN_HEADERS,
+                            json={
+                                "MFACode": mfaCode,
+                                "ReturnUrl": RETURN_URL,
+                                "OpenIdRelayState": "",
+                            },
+                            raise_for_status=True,
+                        ) as resp:
+                            mfaResult = await resp.json()
+                            if not mfaResult["code"]:
+                                raise InvalidAuth(
+                                    "2FA code was invalid. Is the secret wrong?"
+                                )
+                            redirectUrl = mfaResult["authRedirectUrl"]
+                else:
+                    raise InvalidAuth("Login Failed")
+
+            async with session.get(
+                redirectUrl,
+                headers={
+                    "User-Agent": USER_AGENT,
+                },
+                allow_redirects=True,
+                raise_for_status=True,
+            ) as resp:
+                pass
+
+        async with session.get(
+            "https://www.coned.com/sitecore/api/ssc/ConEd-Cms-Services-Controllers-Opower/OpowerService/0/GetOPowerToken",
+            headers={"User-Agent": USER_AGENT},
+            raise_for_status=True,
+        ) as resp:
+            return await resp.json()

--- a/src/opower/utilities/evergy.py
+++ b/src/opower/utilities/evergy.py
@@ -2,6 +2,7 @@
 
 from html.parser import HTMLParser
 import logging
+from typing import Optional
 
 import aiohttp
 
@@ -50,7 +51,10 @@ class Evergy(UtilityBase):
 
     @staticmethod
     async def async_login(
-        session: aiohttp.ClientSession, username: str, password: str
+        session: aiohttp.ClientSession,
+        username: str,
+        password: str,
+        optional_mfa_secret: Optional[str],
     ) -> str:
         """Login to the utility website and authorize opower."""
         login_parser = EvergyLoginParser()

--- a/src/opower/utilities/exelon.py
+++ b/src/opower/utilities/exelon.py
@@ -2,6 +2,7 @@
 
 import json
 import re
+from typing import Optional
 
 import aiohttp
 
@@ -28,7 +29,11 @@ class Exelon:
 
     @classmethod
     async def async_login(
-        cls, session: aiohttp.ClientSession, username: str, password: str
+        cls,
+        session: aiohttp.ClientSession,
+        username: str,
+        password: str,
+        optional_mfa_secret: Optional[str],
     ) -> str:
         """Login to the utility website and authorize opower."""
         async with session.get(

--- a/src/opower/utilities/pge.py
+++ b/src/opower/utilities/pge.py
@@ -1,6 +1,7 @@
 """Pacific Gas & Electric (PG&E)."""
 
 import re
+from typing import Optional
 
 import aiohttp
 
@@ -43,7 +44,10 @@ class PGE(UtilityBase):
 
     @staticmethod
     async def async_login(
-        session: aiohttp.ClientSession, username: str, password: str
+        session: aiohttp.ClientSession,
+        username: str,
+        password: str,
+        optional_mfa_secret: Optional[str],
     ) -> None:
         """Login to the utility website."""
         # 1st way of login

--- a/src/opower/utilities/pse.py
+++ b/src/opower/utilities/pse.py
@@ -2,6 +2,7 @@
 
 from html.parser import HTMLParser
 import re
+from typing import Optional
 
 import aiohttp
 
@@ -77,7 +78,10 @@ class PSE(UtilityBase):
 
     @staticmethod
     async def async_login(
-        session: aiohttp.ClientSession, username: str, password: str
+        session: aiohttp.ClientSession,
+        username: str,
+        password: str,
+        optional_mfa_secret: Optional[str],
     ) -> str:
         """Login to the utility website and authorize opower."""
         login_parser = PSELoginParser()


### PR DESCRIPTION
This adds ConEd (NY) to the supported utility providers. To work around mfa requirements, we allow providing a TOTP secret which we generate 2FA codes from.

The wiring isn't _quite_ complete here. Adding the `optional_auth` currently breaks all the other utilities since they're not expecting that parameter. Do we just add the param to those and don't use it? I'm not quite sure what the proper way to do this in Python is.