### PR TITLE
Add quarter hour aggregate granularity if the account supports it

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "opower"
-version = "0.0.23"
+version = "0.0.24"
 license = {text = "Apache-2.0"}
 authors = [
     { name="tronikos", email="tronikos@gmail.com" },

--- a/src/opower/opower.py
+++ b/src/opower/opower.py
@@ -49,6 +49,7 @@ class AggregateType(Enum):
     BILL = "bill"
     DAY = "day"
     HOUR = "hour"
+    QUARTER_HOUR = "quarter_hour"
 
     def __str__(self):
         """Return the value of the enum."""
@@ -76,6 +77,7 @@ SUPPORTED_AGGREGATE_TYPES = {
         AggregateType.BILL,
         AggregateType.DAY,
         AggregateType.HOUR,
+        AggregateType.QUARTER_HOUR,
     ],
 }
 
@@ -401,6 +403,8 @@ class Opower:
             max_request_days = 363
         elif aggregate_type == AggregateType.HOUR:
             max_request_days = 26
+        elif aggregate_type == AggregateType.QUARTER_HOUR:
+            max_request_days = 6
 
         # Fetch data in batches in reverse chronological order
         # until we reach start or there is no fetched data


### PR DESCRIPTION
This adds support for quarter hour granularity support for utility accounts that indicate it's supported. Example demo.py output from an Evergy account:

```
start_time      end_time        consumption     provided_cost   start_minus_prev_end    end_minus_prev_end
2023-07-31 00:00:00-05:00       2023-07-31 00:15:00-05:00       0.4008  0.042793416     None    None
2023-07-31 00:15:00-05:00       2023-07-31 00:30:00-05:00       0.216   0.02306232      0:00:00 0:15:00
2023-07-31 00:30:00-05:00       2023-07-31 00:45:00-05:00       0.2796  0.029852892     0:00:00 0:15:00
2023-07-31 00:45:00-05:00       2023-07-31 01:00:00-05:00       0.2388  0.025496676     0:00:00 0:15:00
2023-07-31 01:00:00-05:00       2023-07-31 01:15:00-05:00       0.2388  0.025496676     0:00:00 0:15:00
2023-07-31 01:15:00-05:00       2023-07-31 01:30:00-05:00       0.2754  0.029404458     0:00:00 0:15:00
2023-07-31 01:30:00-05:00       2023-07-31 01:45:00-05:00       0.246   0.02626542      0:00:00 0:15:00
2023-07-31 01:45:00-05:00       2023-07-31 02:00:00-05:00       0.186   0.01985922      0:00:00 0:15:00
2023-07-31 02:00:00-05:00       2023-07-31 02:15:00-05:00       0.2514  0.026841978     0:00:00 0:15:00
2023-07-31 02:15:00-05:00       2023-07-31 02:30:00-05:00       0.2352  0.025112304     0:00:00 0:15:00
2023-07-31 02:30:00-05:00       2023-07-31 02:45:00-05:00       0.1914  0.020435778     0:00:00 0:15:00
2023-07-31 02:45:00-05:00       2023-07-31 03:00:00-05:00       0.2322  0.024791994     0:00:00 0:15:00
```

It sounds like there may be accounts that report `readResolution: "QUARTER_HOUR"`, but actually do not have that level of granularity. This should be tested with such an account to see if it fails gracefully or needs any change to accommodate.