### PR TITLE
Add Portland General Electric PGE to utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Supported utilities:
   - PECO Energy Company (PECO)
   - Potomac Electric Power Company (Pepco)
 - Pacific Gas & Electric (PG&E)
-- Puget Sound Energy (PSE)
 - Portland General Electric (PGE)
+- Puget Sound Energy (PSE)
 
 ## Support a new utility
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Supported utilities:
   - Potomac Electric Power Company (Pepco)
 - Pacific Gas & Electric (PG&E)
 - Puget Sound Energy (PSE)
+- Portland General Electric (PGE)
 
 ## Support a new utility
 

--- a/src/opower/utilities/portlandgeneral.py
+++ b/src/opower/utilities/portlandgeneral.py
@@ -1,0 +1,81 @@
+"""Portland General Electric (PGE)."""
+
+import re
+from typing import Optional
+import urllib.parse
+
+import aiohttp
+
+from ..const import USER_AGENT
+from ..exceptions import InvalidAuth
+from .base import UtilityBase
+
+class PGN(UtilityBase):
+    """Portland General Electric (PGE)."""
+
+    @staticmethod
+    def name() -> str:
+        """Distinct recognizable name of the utility."""
+        return "Portland General Electric (PGE)"
+
+    @staticmethod
+    def subdomain() -> str:
+        """Return the opower.com subdomain for this utility."""
+        return "pgn"
+
+    @staticmethod
+    def timezone() -> str:
+        """Return the timezone."""
+        return "America/Los_Angeles"
+
+    @staticmethod
+    async def async_login(
+        session: aiohttp.ClientSession,
+        username: str,
+        password: str,
+        optional_mfa_secret: Optional[str],
+    ) -> None:
+        """Login to the utility website."""
+        async with session.post(
+            "https://identitytoolkit.googleapis.com/v1/accounts:signInWithPassword",
+            headers = {
+                "authority": "identitytoolkit.googleapis.com",
+                "User-Agent": USER_AGENT,
+                "accept": "*/*",
+                "content-type": "application/json",
+                "origin": "https://portlandgeneral.com",
+                "referer": "https://portlandgeneral.com/",
+            },
+            json = {
+                "email": username,
+                "password": password,
+                "returnSecureToken": True,
+            },
+            params = {
+                "key": "AIzaSyDGQGl4SfFoD_KJTo87PboxfNmq89pifqU", #learned from https://github.com/piekstra/portlandgeneral-api
+            },
+            raise_for_status=False,
+        ) as resp:
+            if resp.status == 400:
+                raise InvalidAuth("Username and password failed")
+            result = await resp.json()
+        
+        async with session.post(
+            "https://api.portlandgeneral.com/pg-token-implicit/token",
+            params = {
+                "client_id": "VrrKnd0tw2O4zIM6vqHLYn0PxM3ZW2hY",
+                "response_type": "token",
+                "redirect_uri": ""  # Not sure why this is present with an empty value
+            },
+            headers = {
+                "content-length": "0",
+                "User-Agent": USER_AGENT,
+                "idp_access_token": result.get('idToken'),
+            },
+            raise_for_status=True,
+        ) as resp:
+            result = await resp.json() 
+            if "errorMsg" in result:
+                raise InvalidAuth(result["errorMsg"])
+            return result.get('access_token') 
+        

--- a/src/opower/utilities/portlandgeneral.py
+++ b/src/opower/utilities/portlandgeneral.py
@@ -33,7 +33,7 @@ class PortlandGeneral(UtilityBase):
         username: str,
         password: str,
         optional_mfa_secret: Optional[str],
-    ) -> None:
+    ) -> str:
         """Login to the utility website."""
         async with session.post(
             "https://identitytoolkit.googleapis.com/v1/accounts:signInWithPassword",
@@ -86,4 +86,4 @@ class PortlandGeneral(UtilityBase):
                     "Username and Passord Succeeded, but api responded with "
                     + str(result["errorResponse"])
                 )
-            return result.get("access_token")
+            return str(result.get("access_token"))


### PR DESCRIPTION
Hello. This PR add Portland General Electric, which is available in many parts of Oregon. Portland General is often referred to as PGE, so I just want to point out that is confusing with Pacific Gas & Electric and already used. I've use PGN here since that is the opower subdomain.

There are several "secret" keys used in the flow that I learned from another python project. They are hidden in the login page. Should this be developed like the pge.py that scrapes those from the login page?

I also need to confirm that the error conditions work properly (that failed logins produce useful error messages), but I wanted to get this draft PR in for comments. 