### PR TITLE
Fix Coned: GetOpowerToken now requires Referer header

### DIFF
--- a/src/opower/utilities/coned.py
+++ b/src/opower/utilities/coned.py
@@ -130,7 +130,7 @@ class ConEd(UtilityBase):
             "https://www."
             + hostname
             + "/sitecore/api/ssc/ConEd-Cms-Services-Controllers-Opower/OpowerService/0/GetOPowerToken",
-            headers={"User-Agent": USER_AGENT},
+            headers=login_headers,
             raise_for_status=True,
         ) as resp:
             return str(await resp.json())


### PR DESCRIPTION
See https://github.com/tronikos/opower/issues/47
I did some testing on the headers and it seems that next to the `Cookie` header the `Referer` header also needs to be present. If it is not it will give a 500 error.

Specifically `Referer: https://www.coned.com/` which is already used in the code above, so I reused that and tested