### PR TITLE
Add Seattle City Light support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Supported utilities:
 - Pacific Gas & Electric (PG&E)
 - Portland General Electric (PGE)
 - Puget Sound Energy (PSE)
+- Seattle City Light (SCL)
 
 ## Support a new utility
 

--- a/src/opower/utilities/scl.py
+++ b/src/opower/utilities/scl.py
@@ -1,0 +1,209 @@
+"""Seattle City Light (SCL)."""
+
+from html.parser import HTMLParser
+import json
+import re
+from typing import Optional
+
+import aiohttp
+
+from ..const import USER_AGENT
+from ..exceptions import InvalidAuth
+from .base import UtilityBase
+
+
+def _get_form_action_url_and_hidden_inputs(html: str) -> tuple[str, dict[str, str]]:
+    """Return the URL and hidden inputs from the single form in a page."""
+    match = re.search(r'action="([^"]*)"', html, re.IGNORECASE)
+    if not match:
+        return "", {}
+    action_url = match.group(1)
+    inputs = {}
+    for match in re.finditer(
+        r'input\s*type="hidden"\s*name="([^"]*)"\s*value="([^"]*)"', html,re.IGNORECASE
+    ):
+        inputs[match.group(1)] = match.group(2)
+    return action_url, inputs
+
+def _get_session_storage_values(html:str) -> dict[str, str]:
+    """Returns the items set in session storage on login.seattle.gov"""
+    items = {}
+    for match in re.finditer(
+        r"sessionStorage\.setItem\(\"(.*?)\",\s*['\"](.*)['\"]\)", html
+    ):
+        items[match.group(1)] = match.group(2)
+    return items
+    
+def _get_user_token_from_url(url:str) -> str:
+    match = re.search(r'https://myutilities.seattle.gov/eportal/#/ssohome/(.*)', url)
+    if not match:
+        return ""
+    return match.group(1)
+
+class SCL(UtilityBase):
+    """Seattle City Light (SCL)."""
+
+    @staticmethod
+    def name() -> str:
+        """Distinct recognizable name of the utility."""
+        return "Seattle City Light (SCL)"
+
+    @staticmethod
+    def subdomain() -> str:
+        """Return the opower.com subdomain for this utility."""
+        return "scl"
+
+    @staticmethod
+    def timezone() -> str:
+        """Return the timezone."""
+        return "America/Los_Angeles"
+
+    @staticmethod
+    async def async_login(
+        session: aiohttp.ClientSession,
+        username: str,
+        password: str,
+        optional_mfa_secret: Optional[str],
+    ) -> str:
+        """Login to the utility website."""
+
+        # GET https://myutilities.seattle.gov/rest/auth/ssologin
+        # response has next URL, signature, state, loginCtx in HTML form
+        async with session.get("https://myutilities.seattle.gov/rest/auth/ssologin") as resp:
+            result = await resp.text()
+        action_url, hidden_inputs = _get_form_action_url_and_hidden_inputs(result)
+        if (action_url == "https://login.seattle.gov/#/login?appName=EPORTAL_PROD"):
+            # Not logged in to seattle.gov, go through SSO flow
+            assert set(hidden_inputs.keys()) == {"signature", "state", "loginCtx"}
+
+            # POST to https://login.seattle.gov/#/login?appName=EPORTAL_PROD with signature, state, loginCtx
+            # need to parse signinAT, initialState from html sessionStorage.setItem
+            async with session.post(
+                action_url,
+                data=hidden_inputs,
+                headers={"User-Agent": USER_AGENT},
+                raise_for_status=True,
+            ) as resp:
+                result = await resp.text()
+                session_items = _get_session_storage_values(result)
+            assert set(['initialState', 'signinAT']).issubset(set(session_items.keys()))
+
+            # POST to https://login.seattle.gov/authenticate with credentials, initialState, signinAT?
+            # response has authnToken in JSON response if initialState and signinAT present
+            async with session.post(
+                "https://login.seattle.gov/authenticate",
+                json={
+                    "credentials": {
+                        "username": username,
+                        "password": password
+                    },
+                    "initialState": json.loads(session_items.get("initialState")),
+                    'signinAT': session_items.get("signinAT")
+                },
+                headers={"User-Agent": USER_AGENT},
+                raise_for_status=True,
+            ) as resp:
+                result = await resp.json()
+            if "error_description" in result:
+                raise InvalidAuth(result["error_description"])
+            assert result["authnToken"]
+            authnToken = result["authnToken"]
+
+
+            # POST to https://idcs-3359adb31e35415e8c1729c5c8098c6d.identity.oraclecloud.com/sso/v1/sdk/session with authnToken
+            # response has OCIS_REQ in HTML form
+            async with session.post(
+                "https://idcs-3359adb31e35415e8c1729c5c8098c6d.identity.oraclecloud.com/sso/v1/sdk/session",
+                data={"authnToken": authnToken},
+                headers={"User-Agent": USER_AGENT},
+                raise_for_status=True,
+            ) as resp:
+                result = await resp.text()
+            action_url, hidden_inputs = _get_form_action_url_and_hidden_inputs(result) 
+            assert action_url == "https://idcs-3359adb31e35415e8c1729c5c8098c6d.identity.oraclecloud.com/fed/v1/user/response/login"
+            assert set(hidden_inputs.keys()) == {"OCIS_REQ"}
+
+            # POST to https://idcs-3359adb31e35415e8c1729c5c8098c6d.identity.oraclecloud.com/fed/v1/user/response/login with OCIS_REQ (form data)
+            # response has SAMLResponse in HTML form
+            async with session.post(
+                action_url,
+                data=hidden_inputs,
+                headers={"User-Agent": USER_AGENT},
+                raise_for_status=True,
+            ) as resp:
+                result = await resp.text()
+            action_url, hidden_inputs = _get_form_action_url_and_hidden_inputs(result)
+
+        assert action_url == "https://myutilities.seattle.gov/rest/auth/samlresp"
+        assert set(hidden_inputs.keys()) == {"RelayState", "SAMLResponse"}
+
+
+        # POST to https://myutilities.seattle.gov/rest/auth/samlresp w/ RelayState https://myutilities.seattle.gov/eportal and SAMLResponse
+        # response redirects to https://myutilities.seattle.gov/eportal/#/ssohome/[user_token]
+        # access from location header on hresponse
+        async with session.post(
+            action_url,
+            data=hidden_inputs,
+            headers={"User-Agent": USER_AGENT},
+            raise_for_status=True,
+        ) as resp:
+            url =  resp.real_url.human_repr()
+            user_token = _get_user_token_from_url(url)
+            assert user_token
+
+        # getSSOToken (/auth/token)
+        async with session.post(
+            "https://myutilities.seattle.gov/rest/auth/token",
+            data={
+                "grant_type": "authorization_code",
+                "logintype": "sso",
+                "usertoken": user_token
+            },
+            headers={"User-Agent": USER_AGENT},
+            raise_for_status=True,
+        ) as resp:
+            result = await resp.json()
+        assert result["access_token"]
+        access_token = result["access_token"]
+        customer_id = result["user"]["customerId"]
+
+        # List SCL accounts, required to fetch opower token
+        async with session.post(
+            "https://myutilities.seattle.gov/rest/account/list/some",
+            json={
+                "customerId": customer_id,
+                "companyCode": "SCL",
+                "page": "1",
+                "account": [],
+                "sortColumn": "DUED",
+                "sortOrder": "DESC"
+            },
+            headers={"User-Agent": USER_AGENT, "Authorization": f'Bearer {access_token}'},
+            raise_for_status=True,
+        ) as resp:
+            result = await resp.json()
+        accounts = result["account"]
+
+        if (len(accounts) == 0):
+            raise InvalidAuth("No accounts found")
+
+        # This request lists current accounts by descending due date. Defaults
+        # to taking to the most recent account if there are multiple.
+        account = accounts[0]
+        account_context_keys = ['accountNumber', 'personId', 'companyCd', 'serviceAddress']
+        account_context = {x:account[x] for x in account_context_keys}
+
+        # get opower token (/usage/token)
+        async with session.post(
+            "https://myutilities.seattle.gov/rest/usage/token",
+            json={
+                "customerId": customer_id,
+                "accountContext": account_context
+            },
+            headers={"User-Agent": USER_AGENT, "Authorization": f'Bearer {access_token}'},
+            raise_for_status=True,
+        ) as resp:
+            result = await resp.json()
+        assert result["token"]
+
+        return result["token"]


### PR DESCRIPTION
Adds support for Seattle City Light, the power utility for the city of Seattle and some surrounding municipalities. 

The auth process is a bit more complicated since Seattle utilities uses the seattle.gov SSO, which uses the Oracle Identity Cloud Service, before being able to access the utility dashboard to request the actual Opower token. My Python's somewhat rusty, happy to fix up anything that might look off.

Some example output from running demo.py:

```
start_time      end_time        consumption     provided_cost   start_minus_prev_end    end_minus_prev_end
2023-11-26 00:00:00-08:00       2023-11-27 00:00:00-08:00       38.2674 0       None    None
2023-11-27 00:00:00-08:00       2023-11-28 00:00:00-08:00       38.691  0       0:00:00 1 day, 0:00:00
2023-11-28 00:00:00-08:00       2023-11-29 00:00:00-08:00       37.5528 0       0:00:00 1 day, 0:00:00
2023-11-29 00:00:00-08:00       2023-11-30 00:00:00-08:00       41.5926 0       0:00:00 1 day, 0:00:00
2023-11-30 00:00:00-08:00       2023-12-01 00:00:00-08:00       41.502  0       0:00:00 1 day, 0:00:00
2023-12-01 00:00:00-08:00       2023-12-02 00:00:00-08:00       39.4788 0       0:00:00 1 day, 0:00:00
```