### PR TITLE
 New provider: City of Austin Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Supported utilities (in alphabetical order):
 - Portland General Electric (PGE)
 - Puget Sound Energy (PSE)
 - Seattle City Light (SCL)
+- City of Austin Utilities
 
 ## Support a new utility
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Supported utilities (in alphabetical order):
   - Kentucky Power
   - Public Service Company of Oklahoma (PSO)
   - Southwestern Electric Power Company (SWEPCO)
+- City of Austin Utilities
 - Consolidated Edison (ConEd)
   - Orange & Rockland Utilities (ORU)
 - Enmax Energy
@@ -27,7 +28,6 @@ Supported utilities (in alphabetical order):
 - Portland General Electric (PGE)
 - Puget Sound Energy (PSE)
 - Seattle City Light (SCL)
-- City of Austin Utilities
 
 ## Support a new utility
 

--- a/src/opower/opower.py
+++ b/src/opower/opower.py
@@ -293,7 +293,7 @@ class Opower:
         """Get customers associated to the user."""
         # Cache the customers
         if not self.customers:
-            if not self.user_accounts:
+            if self.utility.is_dss() and not self.user_accounts:
                 await self._async_get_user_accounts()
 
             url = (
@@ -527,7 +527,7 @@ class Opower:
             headers["authorization"] = f"Bearer {self.access_token}"
 
         opower_selected_entities = []
-        if self.user_accounts:
+        if self.utility.is_dss() and self.user_accounts:
             # require for dss endpoints
             opower_selected_entities.append(
                 f'urn:session:account:{self.user_accounts[0]["accountId"]}'

--- a/src/opower/opower.py
+++ b/src/opower/opower.py
@@ -521,7 +521,7 @@ class Opower:
                 return []
             raise err
 
-    def _get_headers(self, customer_uuid: str = None) -> dict[str, str]:
+    def _get_headers(self, customer_uuid: Optional[str] = None) -> dict[str, str]:
         headers = {"User-Agent": USER_AGENT}
         if self.access_token:
             headers["authorization"] = f"Bearer {self.access_token}"
@@ -529,13 +529,13 @@ class Opower:
         opower_selected_entities = []
         if self.user_accounts:
             # require for dss endpoints
-            opower_selected_entities.append(f'urn:session:account:{self.user_accounts[0]["accountId"]}')
+            opower_selected_entities.append(
+                f'urn:session:account:{self.user_accounts[0]["accountId"]}'
+            )
         if customer_uuid:
             opower_selected_entities.append(f"urn:opower:customer:uuid:{customer_uuid}")
         if opower_selected_entities:
-            headers[
-                "Opower-Selected-Entities"
-            ] = json.dumps(opower_selected_entities)
+            headers["Opower-Selected-Entities"] = json.dumps(opower_selected_entities)
         return headers
 
     def _get_subdomain(self) -> str:

--- a/src/opower/opower.py
+++ b/src/opower/opower.py
@@ -528,7 +528,7 @@ class Opower:
 
         opower_selected_entities = []
         if self.utility.is_dss() and self.user_accounts:
-            # require for dss endpoints
+            # Required for dss endpoints
             opower_selected_entities.append(
                 f'urn:session:account:{self.user_accounts[0]["accountId"]}'
             )

--- a/src/opower/utilities/base.py
+++ b/src/opower/utilities/base.py
@@ -41,7 +41,7 @@ class UtilityBase:
 
     @staticmethod
     def is_dss() -> bool:
-        # check if Utility using DSS version of the portal
+        """Check if Utility using DSS version of the portal."""
         return False
 
     @staticmethod

--- a/src/opower/utilities/base.py
+++ b/src/opower/utilities/base.py
@@ -40,6 +40,11 @@ class UtilityBase:
         return False
 
     @staticmethod
+    def is_dss() -> bool:
+        # check if Utility using DSS version of the portal
+        return False
+
+    @staticmethod
     async def async_login(
         session: aiohttp.ClientSession,
         username: str,

--- a/src/opower/utilities/coautilities.py
+++ b/src/opower/utilities/coautilities.py
@@ -17,7 +17,7 @@ class COAUtilities(UtilityBase):
 
     @staticmethod
     def subdomain() -> str:
-        return "dss-coa"
+        return "coa"
 
     @staticmethod
     def timezone() -> str:

--- a/src/opower/utilities/coautilities.py
+++ b/src/opower/utilities/coautilities.py
@@ -24,6 +24,10 @@ class COAUtilities(UtilityBase):
         return "America/Chicago"
 
     @staticmethod
+    def is_dss() -> bool:
+        return True
+
+    @staticmethod
     async def async_login(
         session: aiohttp.ClientSession,
         username: str,
@@ -38,8 +42,11 @@ class COAUtilities(UtilityBase):
 
         # Auth using username and password on coautilities
         url = (
-            "https://coautilities.com/pkmslogin.form?/isam/sps/OPowerIDP_DSS/saml20/logininitial?RequestBinding=HTTPPost"
-            "&NameIdFormat=email&PartnerId=opower-coa-dss-webUser&Target=https://dss-coa.opower.com"
+            "https://coautilities.com/pkmslogin.form?/isam/sps/OPowerIDP_DSS/saml20/logininitial?"
+            "RequestBinding=HTTPPost&"
+            "NameIdFormat=email&"
+            "PartnerId=opower-coa-dss-webUser&"
+            "Target=https://dss-coa.opower.com"
         )
 
         await session.post(
@@ -54,8 +61,9 @@ class COAUtilities(UtilityBase):
 
         # Getting SAML Request from opower
         url = (
-            "https://sso.opower.com/sp/startSSO.ping?PartnerIdpId=https://coautilities.com/isam/sps/OPowerIDP_DSS/saml20"
-            "&TargetResource=https%3A%2F%2Fdss-coa.opower.com%2Fwebcenter%2Fedge%2Fapis%2Fidentity-management-v1%2Fcws"
+            "https://sso.opower.com/sp/startSSO.ping?"
+            "PartnerIdpId=https://coautilities.com/isam/sps/OPowerIDP_DSS/saml20&"
+            "TargetResource=https%3A%2F%2Fdss-coa.opower.com%2Fwebcenter%2Fedge%2Fapis%2Fidentity-management-v1%2Fcws"
             "%2Fv1%2Fauth%2Fcoa%2Fsaml%2Flogin%2Fcallback%3FsuccessUrl%3Dhttps%253A%252F%252Fdss-coa.opower.com%252Fdss"
             "%252Flogin-success%253Ftoken%253D%2525s%2526nextPathname%253DL2Rzcy8%253D%26failureUrl%3Dhttps%253A%252F"
             "%252Fdss-coa.opower.com%252Fdss%252Flogin-error%253Freason%253D%2525s"
@@ -102,9 +110,11 @@ class COAUtilities(UtilityBase):
 
         # Finally exchange this token to Auth token
         async with session.post(
-            "https://dss-coa.opower.com/webcenter/edge/apis/identity-management-v1/cws/v1/auth/coa/saml/ott/confirm",
+            "https://dss-coa.opower.com"
+            "/webcenter/edge/apis/identity-management-v1/cws/v1/auth/coa/saml/ott/confirm",
             headers={"User-Agent": USER_AGENT},
             data={"token": token}
         ) as response:
             content = await response.json()
+            print(content["sessionToken"])
             return content["sessionToken"]

--- a/src/opower/utilities/coautilities.py
+++ b/src/opower/utilities/coautilities.py
@@ -1,0 +1,110 @@
+import re
+from typing import Optional
+
+import aiohttp
+
+from .base import UtilityBase
+from .helpers import get_form_action_url_and_hidden_inputs
+from ..const import USER_AGENT
+
+
+class COAUtilities(UtilityBase):
+    """City of Austin Utilities"""
+
+    @staticmethod
+    def name() -> str:
+        return "City of Austin Utilities"
+
+    @staticmethod
+    def subdomain() -> str:
+        return "dss-coa"
+
+    @staticmethod
+    def timezone() -> str:
+        return "America/Chicago"
+
+    @staticmethod
+    async def async_login(
+        session: aiohttp.ClientSession,
+        username: str,
+        password: str,
+        optional_mfa_secret: Optional[str],
+    ) -> Optional[str]:
+        # Get cookies
+        await session.get(
+            "https://coautilities.com/wps/wcm/connect/occ/coa/home",
+            headers={"User-Agent": USER_AGENT},
+        )
+
+        # Auth using username and password on coautilities
+        url = (
+            "https://coautilities.com/pkmslogin.form?/isam/sps/OPowerIDP_DSS/saml20/logininitial?RequestBinding=HTTPPost"
+            "&NameIdFormat=email&PartnerId=opower-coa-dss-webUser&Target=https://dss-coa.opower.com"
+        )
+
+        await session.post(
+            url,
+            headers={"User-Agent": USER_AGENT},
+            data={
+                "username": username,
+                "password": password,
+                "login-form-type": "pwd",
+            },
+        )
+
+        # Getting SAML Request from opower
+        url = (
+            "https://sso.opower.com/sp/startSSO.ping?PartnerIdpId=https://coautilities.com/isam/sps/OPowerIDP_DSS/saml20"
+            "&TargetResource=https%3A%2F%2Fdss-coa.opower.com%2Fwebcenter%2Fedge%2Fapis%2Fidentity-management-v1%2Fcws"
+            "%2Fv1%2Fauth%2Fcoa%2Fsaml%2Flogin%2Fcallback%3FsuccessUrl%3Dhttps%253A%252F%252Fdss-coa.opower.com%252Fdss"
+            "%252Flogin-success%253Ftoken%253D%2525s%2526nextPathname%253DL2Rzcy8%253D%26failureUrl%3Dhttps%253A%252F"
+            "%252Fdss-coa.opower.com%252Fdss%252Flogin-error%253Freason%253D%2525s"
+        )
+
+        async with session.post(url) as response:
+            html = await response.text()
+            action_url, hidden_inputs = get_form_action_url_and_hidden_inputs(html)
+            assert set(hidden_inputs.keys()) == {"RelayState", "SAMLRequest"}
+
+        # Getting SAML Response from coautilities
+        headers = {
+            "Referer": "https://sso.opower.com/",
+            "User-Agent": USER_AGENT,
+        }
+        async with session.post(
+            action_url,
+            headers=headers,
+            data=hidden_inputs,
+        ) as response:
+            html = await response.text()
+            action_url, hidden_inputs = get_form_action_url_and_hidden_inputs(html)
+            assert set(hidden_inputs.keys()) == {"RelayState", "SAMLResponse"}
+
+        # Getting Open Token from opower
+        async with session.post(
+            action_url,
+            headers={"User-Agent": USER_AGENT},
+            data=hidden_inputs,
+        ) as response:
+            html = await response.text()
+            action_url, hidden_inputs = get_form_action_url_and_hidden_inputs(html)
+            assert set(hidden_inputs.keys()) == {"opentoken"}
+
+        # Getting success token
+        async with session.post(
+            action_url,
+            headers={"User-Agent": USER_AGENT},
+            data=hidden_inputs,
+            allow_redirects=False,
+        ) as response:
+            await response.text()
+            token = re.search(r"token=(.*?)&", response.headers["Location"]).group(1)
+
+        # Finally exchange this token to Auth token
+        async with session.post(
+            "https://dss-coa.opower.com/webcenter/edge/apis/identity-management-v1/cws/v1/auth/coa/saml/ott/confirm",
+            headers={"User-Agent": USER_AGENT},
+            data={"token": token}
+        ) as response:
+            content = await response.json()
+            return content["sessionToken"]


### PR DESCRIPTION
This PR related to issue https://github.com/tronikos/opower/issues/63
Adding support of City of Austin Utilities provider as well as supporting DSS portal type for Opower for this

Tested locally, demo script working fine, run all precommit checks. Not sure how I could test it with HA integration.

One note: I added ability to fetch user accounts from server. Not sure if user could have multiple accounts (it's one in my case) so I hardcoded it to use first every time. In case of some problems in future with this we could think about adding additional user accounts support.