### PR TITLE
New Provider: Duquesne Light

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Supported utilities (in alphabetical order):
 - City of Austin Utilities
 - Consolidated Edison (ConEd)
   - Orange & Rockland Utilities (ORU)
+- Duquesne Light Company (DQE)
 - Enmax Energy
 - Evergy
 - Exelon subsidiaries

--- a/src/opower/utilities/duquesnelight.py
+++ b/src/opower/utilities/duquesnelight.py
@@ -1,0 +1,127 @@
+"""Duquesne Light Company (DQE)."""
+
+from html.parser import HTMLParser
+import re
+from typing import Optional
+
+import aiohttp
+
+from ..const import USER_AGENT
+from ..exceptions import InvalidAuth
+from .base import UtilityBase
+
+
+class DQEUsageParser(HTMLParser):
+    """HTML parser to extract OPower bearer token from DQE Usage page."""
+
+    _regexp = re.compile(r'"OPowerToken": "(?P<token>.+)"')
+
+    def __init__(self) -> None:
+        """Initialize."""
+        super().__init__()
+        self.opower_access_token: Optional[str] = None
+        self._in_inline_script = False
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, Optional[str]]]) -> None:
+        """Recognizes inline scripts."""
+        if (
+            tag == "script"
+            and next(filter(lambda attr: attr[0] == "src", attrs), None) is None
+        ):
+            self._in_inline_script = True
+
+    def handle_data(self, data: str) -> None:
+        """Try to extract the access token from the inline script."""
+        if self._in_inline_script:
+            result = self._regexp.search(data)
+            if result and result.group("token"):
+                self.opower_access_token = result.group("token")
+
+    def handle_endtag(self, tag: str) -> None:
+        """Recognizes the end of inline scripts."""
+        if tag == "script":
+            self._in_inline_script = False
+
+
+class DuquesneLight(UtilityBase):
+    """Duquesne Light Company (DQE)."""
+
+    @staticmethod
+    def name() -> str:
+        """Distinct recognizable name of the utility."""
+        return "Duquesne Light Company (DQE)"
+
+    @staticmethod
+    def subdomain() -> str:
+        """Return the opower.com subdomain for this utility."""
+        return "duq"
+
+    @staticmethod
+    def timezone() -> str:
+        """Return the timezone."""
+        return "America/New_York"
+
+    @staticmethod
+    async def async_login(
+        session: aiohttp.ClientSession,
+        username: str,
+        password: str,
+        optional_mfa_secret: Optional[str],
+    ) -> str:
+        """Login to the utility website."""
+        # Double-logins are somewhat broken if cookies stay around.
+        session.cookie_jar.clear(
+            lambda cookie: cookie["domain"] == "www.duquesnelight.com"
+        )
+        # DQE uses Incapsula and merely passing the User-Agent is not enough.
+        headers = {
+            "User-Agent": USER_AGENT,
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+            "Accept-Language": "en-US,en;q=0.5",
+            "Accept-Encoding": "gzip, deflate",
+            "Connection": "keep-alive",
+            "Upgrade-Insecure-Requests": "1",
+            "Sec-Fetch-Dest": "document",
+            "Sec-Fetch-Mode": "navigate",
+            "Sec-Fetch-Site": "none",
+            "Sec-Fetch-User": "?1",
+            "Cache-Control": "max-age=0",
+        }
+
+        async with session.post(
+            "https://www.duquesnelight.com/login/login",
+            data={
+                "Phone": "",
+                "Email": "",
+                "IsLoginOff": "false",
+                "RedFlagPassword": "",
+                "RememberUsername": "false",
+                "Username": username,
+                "Password": password,
+                "RedirectUrl": "/my-account/account-summary",
+                "SuppressPleaseLoginMessage": "true",
+                "LoginTurnedOffMessage": "",
+                "RedirectPath": "",
+                "PersonId": "",
+            },
+            headers=headers,
+            raise_for_status=True,
+        ) as resp:
+            # Check for failed login - DQE returns status 200 with a json body that can be parsed.
+            if "invalid" in await resp.text():
+                raise InvalidAuth("Login failed")
+
+        usage_parser = DQEUsageParser()
+
+        async with session.get(
+            "https://www.duquesnelight.com/energy-money-savings/my-electric-use",
+            headers=headers,
+            raise_for_status=True,
+        ) as resp:
+            usage_parser.feed(await resp.text())
+
+            assert (
+                usage_parser.opower_access_token
+            ), "Failed to parse OPower bearer token"
+
+        return usage_parser.opower_access_token


### PR DESCRIPTION
Adds support for Duquesne Light Company (DQE), the major provider in Pittsburgh, PA area.  

Example successful output:

```
$ python src/demo.py --utility duquesnelight --username <redacted> --password <redacted> --aggregate_type day

Current bill forecast: Forecast(account=Account(customer=Customer(uuid='<redacted>'), uuid='<redacted>', utility_account_id='<redacted>', meter_type=<MeterType.ELEC: 'ELEC'>, read_resolution=None), start_date=datetime.date(2024, 1, 9), end_date=datetime.date(2024, 2, 7), current_date=datetime.date(2024, 1, 30), unit_of_measure=<UnitOfMeasure.KWH: 'KWH'>, usage_to_date=714.0, cost_to_date=146.0, forecasted_usage=1026.0, forecasted_cost=211.0, typical_usage=578.0, typical_cost=128.0)


Getting historical data: account= Account(customer=Customer(uuid='<redacted>'), uuid='<redacted>', utility_account_id='<redacted>', meter_type=<MeterType.ELEC: 'ELEC'>, read_resolution=<ReadResolution.HOUR: 'HOUR'>) aggregate_type= day start_date= 2024-01-23 19:02:08.742167 end_date= 2024-01-30 19:02:08.742188

start_time	end_time	consumption	provided_cost	start_minus_prev_end	end_minus_prev_end

2024-01-23 00:00:00-05:00	2024-01-24 00:00:00-05:00	30.229	5.843719135	None	None

2024-01-24 00:00:00-05:00	2024-01-25 00:00:00-05:00	32.283	6.240788145	0:00:00	1 day, 0:00:00

2024-01-25 00:00:00-05:00	2024-01-26 00:00:00-05:00	18.499	3.576134185	0:00:00	1 day, 0:00:00

2024-01-26 00:00:00-05:00	2024-01-27 00:00:00-05:00	38.887	7.517440405	0:00:00	1 day, 0:00:00

2024-01-27 00:00:00-05:00	2024-01-28 00:00:00-05:00	51.582	9.97157433	0:00:00	1 day, 0:00:00
```

Example failed login:
```
$ python src/demo.py --utility duquesnelight --username test --password test --aggregate_type day

Traceback (most recent call last):

  File "/home/user/repos/opower/src/demo.py", line 170, in <module>

    asyncio.run(_main())

  File "/usr/lib/python3.10/asyncio/runners.py", line 44, in run

    return loop.run_until_complete(main)

  File "/usr/lib/python3.10/asyncio/base_events.py", line 649, in run_until_complete

    return future.result()

  File "/home/user/repos/opower/src/demo.py", line 86, in _main

    await opower.async_login()

  File "/home/user/repos/opower/src/opower/opower.py", line 194, in async_login

    self.access_token = await self.utility.async_login(

  File "/home/user/repos/opower/src/opower/utilities/duquesnelight.py", line 112, in async_login

    raise InvalidAuth("Login failed")

opower.exceptions.InvalidAuth: Login failed

```

pre-commit:
```
check for added large files..............................................Passed

check python ast.........................................................Passed

check builtin type constructor use.......................................Passed

check for case conflicts.................................................Passed

check docstring is first.................................................Passed

check that executables have shebangs.................(no files to check)Skipped

check json...............................................................Passed

check for merge conflicts................................................Passed

check that scripts with shebangs are executable..........................Passed

check for broken symlinks............................(no files to check)Skipped

check toml...............................................................Passed

check vcs permalinks.....................................................Passed

check xml............................................(no files to check)Skipped

check yaml...............................................................Passed

debug statements (python)................................................Passed

detect destroyed symlinks................................................Passed

detect private key.......................................................Passed

fix end of files.........................................................Passed

fix utf-8 byte order marker..............................................Passed

forbid submodules....................................(no files to check)Skipped

mixed line ending........................................................Passed

trim trailing whitespace.................................................Passed

isort....................................................................Passed

black....................................................................Passed

flake8...................................................................Passed

ruff.....................................................................Passed

mypy.....................................................................Passed

pyupgrade................................................................Passed

yamllint.................................................................Passed

markdownlint.............................................................Passed

codespell................................................................Passed