### PR TITLE
Fix AEP: Always parse out the subdomain, even if already logged in

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "opower"
-version = "0.3.0"
+version = "0.3.1"
 license = {text = "Apache-2.0"}
 authors = [
     { name="tronikos", email="tronikos@gmail.com" },

--- a/src/opower/utilities/aepbase.py
+++ b/src/opower/utilities/aepbase.py
@@ -121,9 +121,15 @@ class AEPBase(ABC):
             headers={"User-Agent": USER_AGENT},
             raise_for_status=True,
         ) as resp:
-            login_parser.feed(await resp.text())
+            text = await resp.text()
+            login_parser.feed(text)
+
 
         if not login_parser.password_field_found:
+            match = re.search(r"https://([^.]*).opower.com", text)
+            assert match
+            cls._subdomain = match.group(1)
+
             # Assume we are already logged in
             return
 


### PR DESCRIPTION
See the issue here: https://github.com/home-assistant/core/issues/110019

Basically, this fixes an assertion bug where the server thinks we're already logged in, and we thus exit, but cls._subdomain isn't set, leading to an assertion error down the line.