### PR TITLE
0.8.5 Return request metadata with forecast

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "opower"
-version = "0.8.4"
+version = "0.8.5"
 license = {text = "Apache-2.0"}
 authors = [
     { name="tronikos", email="tronikos@gmail.com" },

--- a/src/opower/opower.py
+++ b/src/opower/opower.py
@@ -127,6 +127,7 @@ class Forecast:
     forecasted_cost: float
     typical_usage: float
     typical_cost: float
+    metadata: list[str]
 
 
 @dataclasses.dataclass
@@ -313,6 +314,7 @@ class Opower:
                         forecasted_cost=float(forecast.get("forecastedCost", 0)),
                         typical_usage=float(forecast.get("typicalUsage", 0)),
                         typical_cost=float(forecast.get("typicalCost", 0)),
+                        metadata=result["totalMetadata"],
                     )
                 )
         return forecasts


### PR DESCRIPTION
Returns the forecast metadata (ex: `NO_FORECASTED_COST`, `ELEC_COST_ANOMALY`, etc.) with the forecast.