### PR TITLE
APS: Improved APS User Details dictionary access and notify users of Forbidden access

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "opower"
-version = "0.8.4"
+version = "0.8.5"
 license = {text = "Apache-2.0"}
 authors = [
     { name="tronikos", email="tronikos@gmail.com" },


### PR DESCRIPTION
It seems like some APS users either are not enabled for Opower or simply aren't allowed access to it. I updated the APS User Details dictionary access handling to avoid throwing list index out of range errors, as well as to look for any service address id available.

I also updated the APS code to notify the user if a forbidden error is thrown by Opower.

Addresses:
https://github.com/home-assistant/core/issues/128673
https://github.com/home-assistant/core/issues/128810