### PR TITLE
Add support for querying the near-realtime endpoint

### DIFF
--- a/src/opower/utilities/base.py
+++ b/src/opower/utilities/base.py
@@ -49,6 +49,11 @@ class UtilityBase:
         return cls.subdomain()
 
     @staticmethod
+    def supports_realtime_usage() -> bool:
+        """Check if Utility supports realtime usage reads."""
+        return False
+
+    @staticmethod
     async def async_login(
         session: aiohttp.ClientSession,
         username: str,

--- a/src/opower/utilities/coned.py
+++ b/src/opower/utilities/coned.py
@@ -40,6 +40,11 @@ class ConEd(UtilityBase):
         """Return the hostname for login. Allows overriding it for oru.com."""
         return "coned.com"
 
+    @staticmethod
+    def supports_realtime_usage() -> bool:
+        """Check if Utility supports realtime usage reads."""
+        return True
+
     @classmethod
     async def async_login(
         cls,


### PR DESCRIPTION
I've tested this manually with my ConEd account. I only have electricity service so I haven't tested this against a gas account. 

In theory, it looks like an account may have multiple meters, though my account has only one. I've hardcoded the request to only fetch usage data for the first meter on the account. 

Resolves #24 