### PR TITLE
Enmax: fix login

### DIFF
--- a/src/opower/utilities/enmax.py
+++ b/src/opower/utilities/enmax.py
@@ -73,8 +73,9 @@ class Enmax(UtilityBase):
             result = await resp.json()
             access_token = result["access_token"]
 
-        async with session.get(
-            f"https://myaccount.enmax.com/api/account/associated-accounts?token={access_token}",
+        async with session.post(
+            "https://myaccount.enmax.com/api/account/associated-accounts",
+            json={"token": access_token},
             headers={"User-Agent": USER_AGENT},
             raise_for_status=True,
         ) as resp:


### PR DESCRIPTION
Changes the associated-accounts request to a POST instead of a GET.

Resolves home-assistant/core#142024