### PR TITLE
Fix AEP Ohio login flow

### DIFF
--- a/src/opower/utilities/aepbase.py
+++ b/src/opower/utilities/aepbase.py
@@ -4,13 +4,11 @@ from abc import ABC
 from html.parser import HTMLParser
 import re
 from typing import Optional
-import urllib.parse
 
 import aiohttp
 
 from ..const import USER_AGENT
 from ..exceptions import InvalidAuth
-from .helpers import async_auth_saml
 
 
 class AEPLoginParser(HTMLParser):
@@ -42,46 +40,6 @@ class AEPLoginParser(HTMLParser):
             self.inputs[name] = value
 
 
-class AEPTokenParser(HTMLParser):
-    """HTML parser to extract token url and cookie."""
-
-    _regexp = re.compile(r"var cookieKey = '(?P<cookieKey>\w+)'")
-
-    def __init__(self) -> None:
-        """Initialize."""
-        super().__init__()
-        self._in_inline_script = False
-        self.cookieKey: Optional[str] = None
-        self.token_url: Optional[str] = None
-
-    def handle_starttag(self, tag: str, attrs: list[tuple[str, Optional[str]]]) -> None:
-        """Try to extract the token url."""
-        if tag == "iframe":
-            # Look for <iframe src=\"//www.aepohio.com/widgets/sso/opower?token=...&domain=www.aepohio.com\"
-            for a in attrs:
-                if a[0] == "src" and a[1] is not None and "opower" in a[1]:
-                    self.token_url = a[1]
-
-        # Recognizes inline scripts.
-        if (
-            tag == "script"
-            and next(filter(lambda attr: attr[0] == "src", attrs), None) is None
-        ):
-            self._in_inline_script = True
-
-    def handle_data(self, data: str) -> None:
-        """Try to extract the cookie from the inline script."""
-        if self._in_inline_script:
-            result = self._regexp.search(data)
-            if result and result.group("cookieKey"):
-                self.cookieKey = result.group("cookieKey")
-
-    def handle_endtag(self, tag: str) -> None:
-        """Recognizes the end of inline scripts."""
-        if tag == "script":
-            self._in_inline_script = False
-
-
 class AEPBase(ABC):
     """Base Abstract class for American Electric Power."""
 
@@ -110,8 +68,8 @@ class AEPBase(ABC):
         username: str,
         password: str,
         optional_mfa_secret: Optional[str],
-    ) -> str: # MODIFIED: Return type
-        """Login in AEP using user/pass and fetch the AccessToken via AJAX endpoint.""" # MODIFIED: Docstring
+    ) -> str:
+        """Login in AEP using user/pass and return the Opower access token."""
         # Clear cookies before logging in again, in case old ones are still around
         session.cookie_jar.clear(lambda c: c["domain"].endswith("opower.com"))
 
@@ -121,7 +79,7 @@ class AEPBase(ABC):
         async with session.get(
             f"https://www.{cls.hostname()}/account/usage/",
             headers={"User-Agent": USER_AGENT},
-            raise_for_status=True, # Keep True for initial GET
+            raise_for_status=True,
         ) as resp:
             text = await resp.text()
             login_parser.feed(text)
@@ -130,38 +88,35 @@ class AEPBase(ABC):
         post_url = f"https://www.{cls.hostname()}/account/usage/"
         async with session.post(
             post_url,
-            headers={"User-Agent": USER_AGENT, "Content-Type": "application/x-www-form-urlencoded", "Referer": post_url},
-            raise_for_status=False, # MODIFIED: Must be False to allow reading html below
+            headers={
+                "User-Agent": USER_AGENT,
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Referer": post_url,
+            },
+            raise_for_status=True,
             data=login_parser.inputs,
         ) as resp:
             html = await resp.text()
-            # ADDED: Necessary check to replace raise_for_status=True functionality
-            if resp.status != 200:
-                raise InvalidAuth(f"Login POST failed with status {resp.status}")
 
-        # REMOVED: token_parser logic and check
-
-        # Keep original subdomain extraction and assertion
         match = re.search(r"https://([^.]*).opower.com", html)
-        assert match # Reverted to original assert
+        assert match
         cls._subdomain = match.group(1)
 
-        # REMOVED: SAML URL construction and await async_auth_saml
-
-        # --- ADDED: New Token Fetch Logic (Minimal Version) ---
         token_url = f"https://www.{cls.hostname()}/account/oauth/ValidToken"
         token_headers = {
             "User-Agent": USER_AGENT,
             "Accept": "application/json, text/javascript, */*; q=0.01",
             "X-Requested-With": "XMLHttpRequest",
-            "Referer": post_url
+            "Referer": post_url,
         }
-        async with session.get(token_url, headers=token_headers, raise_for_status=True) as token_resp:
+        async with session.get(
+            token_url, headers=token_headers, raise_for_status=True
+        ) as token_resp:
             token_data = await token_resp.json()
-            # Minimal parsing/error handling - relies on structure being correct
             try:
-                access_token = token_data[0]['data']['AccessToken']
-                return access_token # ADDED: Return token
+                access_token = str(token_data[0]["data"]["AccessToken"])
+                return access_token
             except (KeyError, IndexError, TypeError) as e:
-                # Raise InvalidAuth on parsing failure, as original logic would have failed too
-                raise InvalidAuth("Failed to parse access token from JSON response.") from e
+                raise InvalidAuth(
+                    "Failed to parse access token from JSON response."
+                ) from e


### PR DESCRIPTION
Addresses login failures for AEP Ohio users (`InvalidAuth` error).

Debugging revealed that the AEP Ohio website has changed its authentication flow. While the initial credential POST returns a 200 OK status, the expected session tokens (`token_url`, `cookieKey`) are no longer present in the immediate HTML response for the `AEPTokenParser` to find.

Further investigation (inspired by JavaScript found on the post-login page) showed that a secondary, asynchronous request must be made to `/account/oauth/ValidToken` to retrieve the necessary `AccessToken`.

This commit updates the `AEPBase.async_login` method to implement this new flow:
- Performs the initial GET and POST requests to establish a session.
- Checks for a 200 OK status after the POST.
- Makes an additional GET request to `/account/oauth/ValidToken`.
- Parses the JSON response from this endpoint to extract the `AccessToken`.
- Returns the `AccessToken` (method signature changed from `-> None` to `-> str`).
- Removes the now-obsolete `AEPTokenParser` logic and the `async_auth_saml` call for this flow.

Tested successfully using a local debug script for AEP Ohio, confirming successful login and ability to fetch account and usage data subsequently using the retrieved token.