### PR TITLE
Update Duquesne Light login flow

### DIFF
--- a/src/opower/utilities/duquesnelight.py
+++ b/src/opower/utilities/duquesnelight.py
@@ -95,7 +95,7 @@ class DuquesneLight(UtilityBase):
         ) as resp:
             if resp.status == 400:
                 raise InvalidAuth(await resp.text())
-            elif resp.status != 200:
+            if resp.status != 200:
                 resp.raise_for_status()
 
         usage_parser = DQEUsageParser()


### PR DESCRIPTION
Fixes #83 ?

Lots of comments in that issue are regarding the WAF - however, I haven't hit it once (even when reducing all headers to just User Agent) from both a Windows laptop and a Raspberry Pi (in different US states). 🤷‍♂️ I assume Duquesne changed something since someone last tried?

This has been working for me with the CLI. Got daily historical data for a week, plus bill forecast. In addition, also worked in HomeAssistant integration.
