### PR TITLE
Implement GraphQL query for bill forecast data retrieval

### DIFF
--- a/src/opower/opower.py
+++ b/src/opower/opower.py
@@ -284,11 +284,7 @@ class Opower:
                 _LOGGER.debug("Ignoring GraphQL bill forecast error: %s", err)
                 continue
 
-            edges = (
-                result.get("data", {})
-                .get("billingAccountsConnection", {})
-                .get("edges", [])
-            )
+            edges = result.get("data", {}).get("billingAccountsConnection", {}).get("edges", [])
 
             for edge in edges:
                 node = edge.get("node", {})
@@ -308,9 +304,7 @@ class Opower:
                 # Parse ISO 8601 datetime strings, extracting just the date portion
                 start_date = datetime.fromisoformat(start_str).date()
                 end_date = datetime.fromisoformat(end_str).date()
-                current_date = datetime.fromisoformat(
-                    bill_forecast.get("currentDateTime", start_str)
-                ).date()
+                current_date = datetime.fromisoformat(bill_forecast.get("currentDateTime", start_str)).date()
 
                 # Get account identifiers from the node level
                 account_uuid = node.get("uuid", "")
@@ -652,10 +646,7 @@ class Opower:
 
     async def _async_post_graphql(self, query: str, headers: dict[str, str]) -> Any:
         """Execute a GraphQL query against the Opower API."""
-        url = (
-            f"https://{self._get_subdomain()}.opower.com/{self._get_api_root()}"
-            "/edge/apis/dsm-graphql-v1/cws/graphql"
-        )
+        url = f"https://{self._get_subdomain()}.opower.com/{self._get_api_root()}/edge/apis/dsm-graphql-v1/cws/graphql"
         _LOGGER.debug("GraphQL query to: %s", url)
         try:
             async with self.session.post(


### PR DESCRIPTION
This pull request refactors the bill forecast retrieval logic in `src/opower/opower.py` to use a GraphQL API instead of the previous REST endpoint to resolve #162.

**Migration to GraphQL for bill forecast retrieval:**

* Replaced the REST API call in `async_get_forecast` with a GraphQL query, updating the request logic and parsing to match the new response structure. This includes extracting forecast segments, handling service types, and mapping units of measure from the GraphQL response.

* Added a new method `_async_post_graphql` to encapsulate GraphQL query execution, including error handling for HTTP and GraphQL errors, and logging responses for debugging.

**Improvements to data extraction and error handling:**

* Enhanced parsing of forecast data by iterating over segments in the GraphQL response, mapping service types to `MeterType`, and handling unknown units of measure gracefully.

* Improved error handling and debug logging for cases where forecast data is missing or malformed, such as invalid time intervals or unknown service types.