### PR TITLE
Guard against null types in graphql forecast calls

### DIFF
--- a/src/opower/opower.py
+++ b/src/opower/opower.py
@@ -671,4 +671,3 @@ class Opower:
                 return result
         except ClientError as e:
             raise ApiException(f"Client Error: {e}", url=url) from e
-


### PR DESCRIPTION
Should fix https://github.com/tronikos/opower/issues/164
But I am not sure how to best test this