### PR TITLE
Fall back to usage-only reads when cost endpoint returns an error

### DIFF
--- a/src/opower/opower.py
+++ b/src/opower/opower.py
@@ -406,7 +406,15 @@ class Opower:
         The resolution for gas is typically 'day' while for electricity it's hour or quarter hour.
         Opower typically keeps historical cost data for 3 years.
         """
-        reads = await self._async_get_dated_data(account, aggregate_type, start_date, end_date, usage_only)
+        try:
+            reads = await self._async_get_dated_data(account, aggregate_type, start_date, end_date, usage_only)
+        except ApiException:
+            # Some utilities (e.g. ConEd) return HTTP 500 from the cost endpoint
+            # for daily/hourly aggregation. Fall back to usage-only reads.
+            if aggregate_type != AggregateType.BILL and not usage_only:
+                _LOGGER.debug("Cost endpoint failed. Falling back to just usage data.")
+                return await self.async_get_cost_reads(account, aggregate_type, start_date, end_date, usage_only=True)
+            raise
         result: list[CostRead] = []
         for read in reads:
             result.append(

--- a/tests/test_opower.py
+++ b/tests/test_opower.py
@@ -118,6 +118,3 @@ async def test_cost_reads_bill_does_not_fall_back(
 
         with pytest.raises(ApiException):
             await opower.async_get_cost_reads(account, AggregateType.BILL, None, None)
-
-
-# test

--- a/tests/test_opower.py
+++ b/tests/test_opower.py
@@ -1,12 +1,21 @@
 """Tests for Opower."""
 
 from typing import TYPE_CHECKING
+from unittest.mock import Mock
 
 import aiohttp
 import pytest
 
-from opower import Opower, create_cookie_jar, get_supported_utilities
-from opower.exceptions import InvalidAuth
+from opower import (
+    Account,
+    AggregateType,
+    MeterType,
+    Opower,
+    ReadResolution,
+    create_cookie_jar,
+    get_supported_utilities,
+)
+from opower.exceptions import ApiException, InvalidAuth
 
 if TYPE_CHECKING:
     from opower.utilities import UtilityBase
@@ -26,3 +35,89 @@ async def test_invalid_auth(utility: type["UtilityBase"]) -> None:
         )
         with pytest.raises(InvalidAuth):
             await opower.async_login()
+
+
+@pytest.mark.asyncio
+async def test_cost_reads_falls_back_to_usage_on_api_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cost endpoint errors fall back to usage-only reads for non-bill aggregations."""
+    async with aiohttp.ClientSession(cookie_jar=create_cookie_jar()) as session:
+        opower = Opower(
+            session,
+            "Pacific Gas and Electric Company (PG&E)",
+            username="test",
+            password="test",  # noqa: S106
+        )
+
+        account = Account(
+            customer=Mock(),
+            uuid="test-uuid",
+            utility_account_id="test-id",
+            id="test-id",
+            meter_type=MeterType.ELEC,
+            read_resolution=ReadResolution.HOUR,
+        )
+
+        call_log: list[bool] = []  # tracks usage_only values
+
+        async def fake_get_dated_data(
+            acc: object,
+            agg: AggregateType,
+            start: object,
+            end: object,
+            usage_only: bool = False,
+        ) -> list[dict[str, object]]:
+            call_log.append(usage_only)
+            if not usage_only:
+                raise ApiException(message="HTTP Error: 500", url="http://example.com")
+            return [
+                {
+                    "startTime": "2026-01-01T00:00:00-05:00",
+                    "endTime": "2026-01-02T00:00:00-05:00",
+                    "consumption": {"value": 10.0},
+                }
+            ]
+
+        monkeypatch.setattr(opower, "_async_get_dated_data", fake_get_dated_data)
+
+        result = await opower.async_get_cost_reads(account, AggregateType.DAY, None, None)
+        # Should have tried cost first, then fallen back to usage-only
+        assert call_log == [False, True]
+        assert len(result) == 1
+        assert result[0].consumption == 10.0
+        assert result[0].provided_cost == 0.0
+
+
+@pytest.mark.asyncio
+async def test_cost_reads_bill_does_not_fall_back(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bill-level cost endpoint errors should not fall back; they should raise."""
+    async with aiohttp.ClientSession(cookie_jar=create_cookie_jar()) as session:
+        opower = Opower(
+            session,
+            "Pacific Gas and Electric Company (PG&E)",
+            username="test",
+            password="test",  # noqa: S106
+        )
+
+        account = Account(
+            customer=Mock(),
+            uuid="test-uuid",
+            utility_account_id="test-id",
+            id="test-id",
+            meter_type=MeterType.ELEC,
+            read_resolution=ReadResolution.HOUR,
+        )
+
+        async def fake_get_dated_data(*args: object, **kwargs: object) -> list[object]:
+            raise ApiException(message="HTTP Error: 500", url="http://example.com")
+
+        monkeypatch.setattr(opower, "_async_get_dated_data", fake_get_dated_data)
+
+        with pytest.raises(ApiException):
+            await opower.async_get_cost_reads(account, AggregateType.BILL, None, None)
+
+
+# test


### PR DESCRIPTION
There's existing logic to fall back to the usage-only endpoint when the cost endpoint returns empty data (line 428). However, some utilities like ConEd return HTTP 500 from the cost endpoint for daily/hourly aggregation instead of empty data, so the existing fallback never triggers.

This catches `ApiException` from the cost endpoint for non-bill aggregations and retries with `usage_only=True`, matching the existing empty-data fallback behavior. Bill-level errors still raise since there is no alternative endpoint.

The exact error from ConEd:
```
HTTP Error: 500
URL: https://cned.opower.com/.../cws/cost/utilityAccount/<UUID>?aggregateType=day
Response: {"error":{"httpStatus":500,"serviceErrorCode":"UPSTREAM_ERROR",
  "details":"Could not get rated costs and usages for utility account UUID: <UUID>"}}
```

The usage-only endpoint works fine at all granularities for this account.

Related: [home-assistant/core#169223](https://github.com/home-assistant/core/issues/169223)