### PR TITLE
Configure mypy path for pre-commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,6 +43,7 @@ repos:
           - pyotp
           - pytest-mypy
           - python-dotenv
+          - opower
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.38.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,13 +31,18 @@ repos:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
-  - repo: local
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.20.0
     hooks:
       - id: mypy
-        name: mypy
-        entry: mypy --config-file=pyproject.toml
-        language: system
-        types: [python]
+        args: [--config-file=pyproject.toml]
+        additional_dependencies:
+          - aiohttp
+          - aiozoneinfo
+          - arrow
+          - pyotp
+          - pytest-mypy
+          - python-dotenv
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.38.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,19 +31,13 @@ repos:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.20.0
+  - repo: local
     hooks:
       - id: mypy
-        args: [--config-file=pyproject.toml]
-        additional_dependencies:
-          - aiohttp
-          - aiozoneinfo
-          - arrow
-          - pyotp
-          - pytest-mypy
-          - python-dotenv
-          - opower
+        name: mypy
+        entry: mypy --config-file=pyproject.toml
+        language: system
+        types: [python]
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.38.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ max-complexity = 25
 [tool.mypy]
 python_version = "3.11"
 exclude = [".venv", "venv", "build"]
+mypy_path = "src"
 pretty = true
 strict = true
 show_error_codes = true


### PR DESCRIPTION
The mypy pre-commit hook runs in an isolated environment that only has the packages listed in `additional_dependencies`. During a normal `git commit`, pre-commit passes only the changed files to mypy. If the changed file is a test that imports `opower`, mypy does not automatically discover the local `src/` package and fails with `import-not-found` errors.

Instead of adding `opower` to `additional_dependencies` (which would install the published package from PyPI), this configures `mypy_path = "src"` so the hook resolves the local working tree.