### PR TITLE
Localize naive read timestamps to the utility's timezone

### DIFF
--- a/src/opower/opower.py
+++ b/src/opower/opower.py
@@ -7,6 +7,7 @@ from datetime import date, datetime, timedelta
 from enum import Enum
 from typing import Any, ClassVar
 from urllib.parse import urlencode
+from zoneinfo import ZoneInfo
 
 import aiohttp
 import aiozoneinfo
@@ -18,6 +19,20 @@ from .exceptions import ApiException, CannotConnect, InvalidAuth
 from .utilities import UtilityBase
 
 _LOGGER = logging.getLogger(__file__)
+
+
+def _parse_read_time(value: str, tz: ZoneInfo) -> datetime:
+    """Parse an ISO 8601 timestamp returned by the Opower API.
+
+    Some utilities (e.g. City of Austin) return timestamps without a UTC
+    offset. Consumers such as Home Assistant's recorder require timezone-aware
+    timestamps for statistics, so assume the utility's local timezone when the
+    parsed value is naive.
+    """
+    parsed = datetime.fromisoformat(value)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=tz)
+    return parsed
 
 
 class MeterType(Enum):
@@ -474,12 +489,13 @@ class Opower:
                 _LOGGER.debug("Cost endpoint failed. Falling back to just usage data.")
                 return await self.async_get_cost_reads(account, aggregate_type, start_date, end_date, usage_only=True)
             raise
+        tz = await aiozoneinfo.async_get_time_zone(self.utility.timezone())
         result: list[CostRead] = []
         for read in reads:
             result.append(
                 CostRead(
-                    start_time=datetime.fromisoformat(read["startTime"]),
-                    end_time=datetime.fromisoformat(read["endTime"]),
+                    start_time=_parse_read_time(read["startTime"], tz),
+                    end_time=_parse_read_time(read["endTime"], tz),
                     consumption=(read["value"] if "value" in read else read["consumption"]["value"]),
                     provided_cost=read.get("providedCost", 0) or 0,
                 )
@@ -510,12 +526,13 @@ class Opower:
         Opower typically keeps historical usage data for a bit over 3 years.
         """
         reads = await self._async_get_dated_data(account, aggregate_type, start_date, end_date, usage_only=True)
+        tz = await aiozoneinfo.async_get_time_zone(self.utility.timezone())
         result: list[UsageRead] = []
         for read in reads:
             result.append(
                 UsageRead(
-                    start_time=datetime.fromisoformat(read["startTime"]),
-                    end_time=datetime.fromisoformat(read["endTime"]),
+                    start_time=_parse_read_time(read["startTime"], tz),
+                    end_time=_parse_read_time(read["endTime"], tz),
                     consumption=read["consumption"]["value"],
                 )
             )
@@ -561,10 +578,11 @@ class Opower:
         )
         headers = self._get_headers(account.customer.uuid)
         result = await self._async_get_request(url, {}, headers)
+        tz = await aiozoneinfo.async_get_time_zone(self.utility.timezone())
         return [
             UsageRead(
-                start_time=datetime.fromisoformat(read["startTime"]),
-                end_time=datetime.fromisoformat(read["endTime"]),
+                start_time=_parse_read_time(read["startTime"], tz),
+                end_time=_parse_read_time(read["endTime"], tz),
                 consumption=read["value"],
             )
             for read in result["reads"]

--- a/tests/test_opower.py
+++ b/tests/test_opower.py
@@ -1,7 +1,9 @@
 """Tests for Opower."""
 
+from datetime import datetime
 from typing import TYPE_CHECKING
 from unittest.mock import Mock
+from zoneinfo import ZoneInfo
 
 import aiohttp
 import pytest
@@ -118,3 +120,56 @@ async def test_cost_reads_bill_does_not_fall_back(
 
         with pytest.raises(ApiException):
             await opower.async_get_cost_reads(account, AggregateType.BILL, None, None)
+
+
+@pytest.mark.asyncio
+async def test_naive_read_times_localized_to_utility_timezone(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reads without a UTC offset are localized to the utility's timezone.
+
+    Some utilities (e.g. City of Austin) return timestamps with no offset.
+    Statistics consumers (such as Home Assistant's recorder) require
+    timezone-aware datetimes, so naive values must be localized rather than
+    passed through unchanged.
+    """
+    async with aiohttp.ClientSession(cookie_jar=create_cookie_jar()) as session:
+        opower = Opower(
+            session,
+            "City of Austin Utilities",
+            username="test",
+            password="test",  # noqa: S106
+        )
+
+        account = Account(
+            customer=Mock(),
+            uuid="test-uuid",
+            utility_account_id="test-id",
+            id="test-id",
+            meter_type=MeterType.ELEC,
+            read_resolution=ReadResolution.DAY,
+        )
+
+        async def fake_get_dated_data(
+            *args: object,
+            **kwargs: object,
+        ) -> list[dict[str, object]]:
+            return [
+                {
+                    "startTime": "2026-06-01T00:00:00",
+                    "endTime": "2026-06-02T00:00:00",
+                    "consumption": {"value": 10.0},
+                    "providedCost": 1.23,
+                }
+            ]
+
+        monkeypatch.setattr(opower, "_async_get_dated_data", fake_get_dated_data)
+
+        result = await opower.async_get_cost_reads(account, AggregateType.DAY, None, None)
+
+        tz = ZoneInfo("America/Chicago")
+        assert len(result) == 1
+        assert result[0].start_time == datetime(2026, 6, 1, tzinfo=tz)
+        assert result[0].end_time == datetime(2026, 6, 2, tzinfo=tz)
+        assert result[0].start_time.tzinfo is not None
+        assert result[0].end_time.tzinfo is not None


### PR DESCRIPTION
## Problem

`datetime.fromisoformat()` returns a **naive** datetime when the API timestamp string has no UTC offset. Some utilities (confirmed for **City of Austin Utilities**) return offset-less timestamps like `2026-06-01T00:00:00`, so `CostRead`/`UsageRead` `start_time`/`end_time` come out timezone-naive.

Downstream consumers that require timezone-aware datetimes then fail. In Home Assistant (2026.6.3) the recorder rejects them and the `opower` coordinator errors on **every** refresh (~6/hour), writing no statistics:

```
File ".../homeassistant/components/opower/coordinator.py", line 364, in _insert_statistics
    async_add_external_statistics(self.hass, cost_metadata, cost_statistics)
File ".../homeassistant/components/recorder/statistics.py", line 2801, in _async_import_statistics
    raise HomeAssistantError("Naive timestamp: no or invalid timezone info provided")
```

The statistics' `start` comes directly from `CostRead.start_time`, so the naive value originates here in the library.

## Fix

Localize naive parsed timestamps to the utility's timezone (already available via `utility.timezone()`) in the three read parsers — `async_get_cost_reads`, `async_get_usage_reads`, and `async_get_realtime_usage_reads`. Already-aware timestamps (the common case for utilities whose API includes an offset) pass through unchanged.

A small helper `_parse_read_time(value, tz)` does the parse + conditional localize.

## Test

Added `test_naive_read_times_localized_to_utility_timezone` (mirrors the existing `_async_get_dated_data` mock pattern): feeds offset-less reads through City of Austin and asserts the resulting `start_time`/`end_time` are timezone-aware and localized to `America/Chicago`.

Verified locally: `ruff check`, `ruff format --check`, `mypy`, and `pytest tests/test_opower.py` all pass.