### PR TITLE
Add new utility provider: Rhode Island Energy

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ This library is used by the [Opower integration in Home Assistant](https://www.h
 - Pacific Gas & Electric (PG&E)
 - Portland General Electric (PGE)
 - Puget Sound Energy (PSE)
+- Rhode Island Energy (RIEnergy)
 - Sacramento Municipal Utility District (SMUD)
 - Seattle City Light (SCL)
 - Southern Maryland Electric Cooperative (SMECO)

--- a/src/opower/utilities/rienergy.py
+++ b/src/opower/utilities/rienergy.py
@@ -11,7 +11,6 @@ import aiohttp
 
 # --- FIX: Import the USER_AGENT constant ---
 from ..const import USER_AGENT
-from ..exceptions import InvalidAuth
 from .base import UtilityBase
 
 

--- a/src/opower/utilities/rienergy.py
+++ b/src/opower/utilities/rienergy.py
@@ -49,11 +49,9 @@ class RhodeIslandEnergy(UtilityBase):
         api_url = f"{base_url}/ei/edge/apis/user-account-control-v1/cws/v1/{self.utilitycode()}/account/signin"
 
         # 2. Execute Login
-        payload = {"username": username, "password": password}
-
         async with session.post(
             api_url,
-            json=payload,
+            json={"username": username, "password": password}
             headers={"User-Agent": USER_AGENT},
             raise_for_status=True,
         ) as _:

--- a/src/opower/utilities/rienergy.py
+++ b/src/opower/utilities/rienergy.py
@@ -24,6 +24,10 @@ class RhodeIslandEnergy(UtilityBase):
 
     def subdomain(self) -> str:
         """Return the opower.com subdomain for this utility."""
+        return "rienergy"
+
+    def utilitycode(self) -> str:
+        """Return the utilitycode identifier for the utility."""
         return "ngri"
 
     @staticmethod
@@ -45,7 +49,7 @@ class RhodeIslandEnergy(UtilityBase):
     ) -> str | None:
         """Authenticate against the RIEnergy Opower portal."""
         # 1. Define URLs
-        base_url = f"https://rienergy.opower.com"
+        base_url = f"https://{self.subdomain()}.opower.com"
         login_page_url = f"{base_url}/ei/x/sign-in-wall?source=intercepted"
         api_url = f"{base_url}/ei/edge/apis/user-account-control-v1/cws/v1/{self.subdomain()}/account/signin"
 

--- a/src/opower/utilities/rienergy.py
+++ b/src/opower/utilities/rienergy.py
@@ -24,7 +24,7 @@ class RhodeIslandEnergy(UtilityBase):
 
     def subdomain(self) -> str:
         """Return the opower.com subdomain for this utility."""
-        return "rienergy"
+        return "ngri"
 
     @staticmethod
     def timezone() -> str:
@@ -45,9 +45,9 @@ class RhodeIslandEnergy(UtilityBase):
     ) -> str | None:
         """Authenticate against the RIEnergy Opower portal."""
         # 1. Define URLs
-        base_url = f"https://{self.subdomain()}.opower.com"
+        base_url = f"https://rienergy.opower.com"
         login_page_url = f"{base_url}/ei/x/sign-in-wall?source=intercepted"
-        api_url = f"{base_url}/ei/edge/apis/user-account-control-v1/cws/v1/ngri/account/signin"
+        api_url = f"{base_url}/ei/edge/apis/user-account-control-v1/cws/v1/{self.subdomain()}/account/signin"
 
         # 2. Define Headers
         # --- FIX: Use the imported USER_AGENT constant instead of hardcoding one ---

--- a/src/opower/utilities/rienergy.py
+++ b/src/opower/utilities/rienergy.py
@@ -35,11 +35,6 @@ class RhodeIslandEnergy(UtilityBase):
         """Return the timezone for this utility."""
         return "America/New_York"
 
-    @staticmethod
-    def is_dss() -> bool:
-        """Indicate that this utility uses the DSS version of the portal."""
-        return False
-
     async def async_login(
         self,
         session: aiohttp.ClientSession,
@@ -61,12 +56,7 @@ class RhodeIslandEnergy(UtilityBase):
             "Accept-Language": "en-US,en;q=0.9",
         }
 
-        # 3. Warm up the session
-        # We just call the context manager to get the cookies
-        async with session.get(login_page_url, headers=headers):
-            pass
-
-        # 4. Prepare Login Headers
+        # 3. Prepare Login Headers
         login_headers = headers.copy()
         login_headers.update(
             {
@@ -77,7 +67,7 @@ class RhodeIslandEnergy(UtilityBase):
             }
         )
 
-        # 5. Execute Login
+        # 4. Execute Login
         payload = {"username": username, "password": password}
 
         async with session.post(

--- a/src/opower/utilities/rienergy.py
+++ b/src/opower/utilities/rienergy.py
@@ -51,7 +51,7 @@ class RhodeIslandEnergy(UtilityBase):
         # 2. Execute Login
         async with session.post(
             api_url,
-            json={"username": username, "password": password}
+            json={"username": username, "password": password},
             headers={"User-Agent": USER_AGENT},
             raise_for_status=True,
         ) as _:

--- a/src/opower/utilities/rienergy.py
+++ b/src/opower/utilities/rienergy.py
@@ -1,6 +1,6 @@
-"""Rhode Island Energy (RIEnergy).
+"""Rhode Island Energy (RIEnergy)."""
 
-At the time of this commit, this appears to be an unmaintained system for RIEnergy.
+"""At the time of this commit, this appears to be an unmaintained system for RIEnergy.
 Accounts do not appear to correctly return as solar even if they are,
 so only consumption (will be net if net metered, but will bottom out at 0) and cost data
 are available, with a resolution of "BILLING".

--- a/src/opower/utilities/rienergy.py
+++ b/src/opower/utilities/rienergy.py
@@ -47,7 +47,7 @@ class RhodeIslandEnergy(UtilityBase):
         # 1. Define URLs
         base_url = f"https://{self.subdomain()}.opower.com"
         login_page_url = f"{base_url}/ei/x/sign-in-wall?source=intercepted"
-        api_url = f"{base_url}/ei/edge/apis/user-account-control-v1/cws/v1/{self.subdomain()}/account/signin"
+        api_url = f"{base_url}/ei/edge/apis/user-account-control-v1/cws/v1/ngri/account/signin"
 
         # 2. Define Headers
         # --- FIX: Use the imported USER_AGENT constant instead of hardcoding one ---

--- a/src/opower/utilities/rienergy.py
+++ b/src/opower/utilities/rienergy.py
@@ -1,4 +1,5 @@
 """Rhode Island Energy (RIEnergy).
+
 At the time of this commit, this appears to be an unmaintained system for RIEnergy.
 Accounts do not appear to correctly return as solar even if they are,
 so only consumption (will be net if net metered, but will bottom out at 0) and cost data
@@ -49,7 +50,6 @@ class RhodeIslandEnergy(UtilityBase):
         """Authenticate against the RIEnergy Opower portal."""
         # 1. Define URLs
         base_url = f"https://{self.subdomain()}.opower.com"
-        login_page_url = f"{base_url}/ei/x/sign-in-wall?source=intercepted"
         api_url = f"{base_url}/ei/edge/apis/user-account-control-v1/cws/v1/{self.utilitycode()}/account/signin"
 
         # 2. Execute Login

--- a/src/opower/utilities/rienergy.py
+++ b/src/opower/utilities/rienergy.py
@@ -1,0 +1,105 @@
+"""Rhode Island Energy (RIEnergy)."""
+
+from typing import Any
+
+import aiohttp
+
+# --- FIX: Import the USER_AGENT constant ---
+from ..const import USER_AGENT
+from ..exceptions import InvalidAuth
+from .base import UtilityBase
+
+
+class RhodeIslandEnergy(UtilityBase):
+    """Rhode Island Energy (RIEnergy).
+
+    This utility uses the Opower portal at `rienergy.opower.com`.
+    Login is handled via the 'user-account-control-v1' API endpoint.
+    """
+
+    @staticmethod
+    def name() -> str:
+        """Return a distinct, human-readable name for this utility."""
+        return "Rhode Island Energy (RIEnergy)"
+
+    def subdomain(self) -> str:
+        """Return the opower.com subdomain for this utility."""
+        return "rienergy"
+
+    @staticmethod
+    def timezone() -> str:
+        """Return the timezone for this utility."""
+        return "America/New_York"
+
+    @staticmethod
+    def is_dss() -> bool:
+        """Indicate that this utility uses the DSS version of the portal."""
+        return False
+
+    async def async_login(
+        self,
+        session: aiohttp.ClientSession,
+        username: str,
+        password: str,
+        login_data: dict[str, Any],
+    ) -> str | None:
+        """Authenticate against the RIEnergy Opower portal."""
+        # 1. Define URLs
+        base_url = f"https://{self.subdomain()}.opower.com"
+        login_page_url = f"{base_url}/ei/x/sign-in-wall?source=intercepted"
+        api_url = f"{base_url}/ei/edge/apis/user-account-control-v1/cws/v1/{self.subdomain()}/account/signin"
+
+        # 2. Define Headers
+        # --- FIX: Use the imported USER_AGENT constant instead of hardcoding one ---
+        headers = {
+            "User-Agent": USER_AGENT,
+            "Accept": "application/json, text/plain, */*",
+            "Accept-Language": "en-US,en;q=0.9",
+        }
+
+        # 3. Warm up the session
+        # We just call the context manager to get the cookies
+        async with session.get(login_page_url, headers=headers):
+            pass
+
+        # 4. Prepare Login Headers
+        login_headers = headers.copy()
+        login_headers.update(
+            {
+                "Content-Type": "application/json",
+                "Origin": base_url,
+                "Referer": login_page_url,
+                "X-Requested-With": "XMLHttpRequest",
+            }
+        )
+
+        # 5. Execute Login
+        payload = {"username": username, "password": password}
+
+        async with session.post(
+            api_url,
+            json=payload,
+            headers=login_headers,
+            raise_for_status=False,
+        ) as resp:
+            # --- HANDLE 204 SUCCESS ---
+            if resp.status == 204:
+                return "cookie-auth-success"
+
+            # If it's not 200 or 204, fail.
+            if resp.status != 200:
+                error_text = await resp.text()
+                raise InvalidAuth(f"Login failed: {resp.status} - {error_text}")
+
+            try:
+                result = await resp.json()
+            except Exception as exc:
+                raise InvalidAuth("Unexpected response from RIEnergy login") from exc
+
+        # 6. Extract Token (Only if response was 200 JSON)
+        token = result.get("sessionToken") or result.get("accessToken")
+
+        if not token:
+            raise InvalidAuth(f"Login failed; token not found. Response keys: {list(result.keys())}")
+
+        return str(token)

--- a/src/opower/utilities/rienergy.py
+++ b/src/opower/utilities/rienergy.py
@@ -10,7 +10,6 @@ from typing import Any
 
 import aiohttp
 
-# --- FIX: Import the USER_AGENT constant ---
 from ..const import USER_AGENT
 from .base import UtilityBase
 
@@ -48,11 +47,9 @@ class RhodeIslandEnergy(UtilityBase):
         login_data: dict[str, Any],
     ) -> None:
         """Authenticate against the RIEnergy Opower portal."""
-        # 1. Define URLs
         base_url = f"https://{self.subdomain()}.opower.com"
         api_url = f"{base_url}/ei/edge/apis/user-account-control-v1/cws/v1/{self.utilitycode()}/account/signin"
 
-        # 2. Execute Login
         async with session.post(
             api_url,
             json={"username": username, "password": password},

--- a/src/opower/utilities/rienergy.py
+++ b/src/opower/utilities/rienergy.py
@@ -53,8 +53,8 @@ class RhodeIslandEnergy(UtilityBase):
         # --- FIX: Use the imported USER_AGENT constant instead of hardcoding one ---
         headers = {
             "User-Agent": USER_AGENT,
-            "Accept": "application/json, text/plain, */*",
-            "Accept-Language": "en-US,en;q=0.9",
+            "Accept": "*/*",
+            "Accept-Language": "en-US",
         }
 
         # 3. Warm up the session

--- a/src/opower/utilities/rienergy.py
+++ b/src/opower/utilities/rienergy.py
@@ -48,32 +48,13 @@ class RhodeIslandEnergy(UtilityBase):
         login_page_url = f"{base_url}/ei/x/sign-in-wall?source=intercepted"
         api_url = f"{base_url}/ei/edge/apis/user-account-control-v1/cws/v1/{self.utilitycode()}/account/signin"
 
-        # 2. Define Headers
-        # --- FIX: Use the imported USER_AGENT constant instead of hardcoding one ---
-        headers = {
-            "User-Agent": USER_AGENT,
-            "Accept": "application/json, text/plain, */*",
-            "Accept-Language": "en-US,en;q=0.9",
-        }
-
-        # 3. Prepare Login Headers
-        login_headers = headers.copy()
-        login_headers.update(
-            {
-                "Content-Type": "application/json",
-                "Origin": base_url,
-                "Referer": login_page_url,
-                "X-Requested-With": "XMLHttpRequest",
-            }
-        )
-
-        # 4. Execute Login
+        # 2. Execute Login
         payload = {"username": username, "password": password}
 
         async with session.post(
             api_url,
             json=payload,
-            headers=login_headers,
+            headers={"User-Agent": USER_AGENT},
             raise_for_status=True,
         ) as _:
             pass

--- a/src/opower/utilities/rienergy.py
+++ b/src/opower/utilities/rienergy.py
@@ -46,7 +46,7 @@ class RhodeIslandEnergy(UtilityBase):
         username: str,
         password: str,
         login_data: dict[str, Any],
-    ) -> str | None:
+    ) -> None:
         """Authenticate against the RIEnergy Opower portal."""
         # 1. Define URLs
         base_url = f"https://{self.subdomain()}.opower.com"
@@ -84,26 +84,6 @@ class RhodeIslandEnergy(UtilityBase):
             api_url,
             json=payload,
             headers=login_headers,
-            raise_for_status=False,
-        ) as resp:
-            # --- HANDLE 204 SUCCESS ---
-            if resp.status == 204:
-                return "cookie-auth-success"
-
-            # If it's not 200 or 204, fail.
-            if resp.status != 200:
-                error_text = await resp.text()
-                raise InvalidAuth(f"Login failed: {resp.status} - {error_text}")
-
-            try:
-                result = await resp.json()
-            except Exception as exc:
-                raise InvalidAuth("Unexpected response from RIEnergy login") from exc
-
-        # 6. Extract Token (Only if response was 200 JSON)
-        token = result.get("sessionToken") or result.get("accessToken")
-
-        if not token:
-            raise InvalidAuth(f"Login failed; token not found. Response keys: {list(result.keys())}")
-
-        return str(token)
+            raise_for_status=True,
+        ) as _:
+            pass

--- a/src/opower/utilities/rienergy.py
+++ b/src/opower/utilities/rienergy.py
@@ -51,14 +51,14 @@ class RhodeIslandEnergy(UtilityBase):
         # 1. Define URLs
         base_url = f"https://{self.subdomain()}.opower.com"
         login_page_url = f"{base_url}/ei/x/sign-in-wall?source=intercepted"
-        api_url = f"{base_url}/ei/edge/apis/user-account-control-v1/cws/v1/{self.subdomain()}/account/signin"
+        api_url = f"{base_url}/ei/edge/apis/user-account-control-v1/cws/v1/{self.utilitycode()}/account/signin"
 
         # 2. Define Headers
         # --- FIX: Use the imported USER_AGENT constant instead of hardcoding one ---
         headers = {
             "User-Agent": USER_AGENT,
-            "Accept": "*/*",
-            "Accept-Language": "en-US",
+            "Accept": "application/json, text/plain, */*",
+            "Accept-Language": "en-US,en;q=0.9",
         }
 
         # 3. Warm up the session

--- a/src/opower/utilities/rienergy.py
+++ b/src/opower/utilities/rienergy.py
@@ -1,4 +1,9 @@
-"""Rhode Island Energy (RIEnergy)."""
+"""Rhode Island Energy (RIEnergy).
+At the time of this commit, this appears to be an unmaintained system for RIEnergy.
+Accounts do not appear to correctly return as solar even if they are,
+so only consumption (will be net if net metered, but will bottom out at 0) and cost data
+are available, with a resolution of "BILLING".
+"""
 
 from typing import Any
 

--- a/src/opower/utilities/rienergy.py
+++ b/src/opower/utilities/rienergy.py
@@ -1,6 +1,6 @@
-"""Rhode Island Energy (RIEnergy)."""
+"""Rhode Island Energy (RIEnergy).
 
-"""At the time of this commit, this appears to be an unmaintained system for RIEnergy.
+At the time of this commit, this appears to be an unmaintained system for RIEnergy.
 Accounts do not appear to correctly return as solar even if they are,
 so only consumption (will be net if net metered, but will bottom out at 0) and cost data
 are available, with a resolution of "BILLING".


### PR DESCRIPTION
Unfortunately RIEnergy appears to have inherited their opower integration from when they were national grid, system is of limited use, and does not appear to be well maintained. For example systems that are solar report as not being solar and do not expose generation data. However it is useful for pulling net usage data (does not appear to go negative though) and will properly display bill totals, however it does not show any available credits. The only available resolution appears to be "BILLING". Still this is somewhat useful data.