### PR TITLE
Support five minute read resolution

### DIFF
--- a/src/opower/opower.py
+++ b/src/opower/opower.py
@@ -81,6 +81,7 @@ class ReadResolution(Enum):
     HOUR = "HOUR"
     HALF_HOUR = "HALF_HOUR"
     QUARTER_HOUR = "QUARTER_HOUR"
+    FIVE_MINUTE = "FIVE_MINUTE"
 
     def __str__(self) -> str:
         """Return the value of the enum."""
@@ -98,6 +99,13 @@ SUPPORTED_AGGREGATE_TYPES = {
         AggregateType.HALF_HOUR,
     ],
     ReadResolution.QUARTER_HOUR: [
+        AggregateType.BILL,
+        AggregateType.DAY,
+        AggregateType.HOUR,
+        AggregateType.HALF_HOUR,
+        AggregateType.QUARTER_HOUR,
+    ],
+    ReadResolution.FIVE_MINUTE: [
         AggregateType.BILL,
         AggregateType.DAY,
         AggregateType.HOUR,

--- a/tests/test_opower.py
+++ b/tests/test_opower.py
@@ -123,6 +123,62 @@ async def test_cost_reads_bill_does_not_fall_back(
 
 
 @pytest.mark.asyncio
+async def test_five_minute_read_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Parse five-minute accounts and allow existing fine-grained aggregations."""
+    async with aiohttp.ClientSession(cookie_jar=create_cookie_jar()) as session:
+        opower = Opower(
+            session,
+            "Consolidated Edison (ConEd)",
+            username="test",
+            password="test",  # noqa: S106
+        )
+
+        async def fake_get_customers() -> list[dict[str, object]]:
+            return [
+                {
+                    "uuid": "customer-uuid",
+                    "utilityAccounts": [
+                        {
+                            "uuid": "account-uuid",
+                            "preferredUtilityAccountId": "account-id",
+                            "meterType": "ELEC",
+                            "readResolution": "FIVE_MINUTE",
+                        }
+                    ],
+                }
+            ]
+
+        calls: list[AggregateType] = []
+
+        async def fake_async_fetch(
+            account: Account,
+            aggregate_type: AggregateType,
+            start_date: datetime | None = None,
+            end_date: datetime | None = None,
+            usage_only: bool = False,
+        ) -> list[dict[str, object]]:
+            calls.append(aggregate_type)
+            return [{"start": start_date, "end": end_date, "usage_only": usage_only}]
+
+        monkeypatch.setattr(opower, "_async_get_customers", fake_get_customers)
+        monkeypatch.setattr(opower, "_async_fetch", fake_async_fetch)
+
+        accounts = await opower.async_get_accounts()
+
+        assert len(accounts) == 1
+        assert accounts[0].read_resolution is ReadResolution.FIVE_MINUTE
+        await opower._async_get_dated_data(
+            accounts[0],
+            AggregateType.QUARTER_HOUR,
+            datetime(2026, 1, 1),
+            datetime(2026, 1, 1),
+        )
+        assert calls == [AggregateType.QUARTER_HOUR]
+
+
+@pytest.mark.asyncio
 async def test_naive_read_times_localized_to_utility_timezone(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- add `FIVE_MINUTE` as a supported Opower account read resolution
- allow five-minute accounts to use the existing bill/day/hour/half-hour/quarter-hour aggregate types
- add a regression test covering account parsing for `readResolution: FIVE_MINUTE`

This addresses the `ValueError: 'FIVE_MINUTE' is not a valid ReadResolution` failure reported by Home Assistant users in home-assistant/core#172751.

## Validation
- `python -m pytest tests/test_opower.py::test_five_minute_read_resolution`
- `python -m pytest tests/test_opower.py -k "not invalid_auth"`
- `python -m ruff check .`