### PR TITLE
Fix Portland General Electric (PGE) login: PGE migrated from Firebase to AWS Cognito

### DIFF
--- a/src/opower/utilities/portlandgeneral.py
+++ b/src/opower/utilities/portlandgeneral.py
@@ -5,8 +5,28 @@ from typing import Any
 import aiohttp
 
 from ..const import USER_AGENT
-from ..exceptions import InvalidAuth
+from ..exceptions import CannotConnect, InvalidAuth
 from .base import UtilityBase
+
+# PGE migrated their identity provider from Firebase to AWS Cognito around
+# June 2026, which broke the previous identitytoolkit.googleapis.com-based
+# login. These values were learned from portlandgeneral.com's own web app.
+_COGNITO_REGION = "us-west-2"
+_COGNITO_CLIENT_ID = "4q9nbgmi0gcks5t7d6fkhubfnm"
+_APIGEE_CLIENT_ID = "rHuS10KrfsLwFAr2sZ7MHh7oHELGx6YK"
+
+# Cognito error types that genuinely mean "these credentials are wrong",
+# as opposed to throttling/5xx/other transient errors, which should
+# surface as CannotConnect instead of telling the user their password
+# is bad during an outage.
+_COGNITO_AUTH_ERROR_TYPES = frozenset(
+    {
+        "NotAuthorizedException",
+        "UserNotFoundException",
+        "PasswordResetRequiredException",
+        "UserNotConfirmedException",
+    }
+)
 
 
 class PortlandGeneral(UtilityBase):
@@ -34,54 +54,109 @@ class PortlandGeneral(UtilityBase):
         login_data: dict[str, Any],
     ) -> str:
         """Login to the utility website."""
-        async with (
-            session.post(
-                "https://identitytoolkit.googleapis.com/v1/accounts:signInWithPassword",
-                headers={
-                    "authority": "identitytoolkit.googleapis.com",
-                    "User-Agent": USER_AGENT,
-                    "accept": "*/*",
-                    "content-type": "application/json",
-                    "origin": "https://portlandgeneral.com",
-                    "referer": "https://portlandgeneral.com/",
+        async with session.post(
+            f"https://cognito-idp.{_COGNITO_REGION}.amazonaws.com/",
+            headers={
+                "User-Agent": USER_AGENT,
+                "Content-Type": "application/x-amz-json-1.1",
+                "X-Amz-Target": "AWSCognitoIdentityProviderService.InitiateAuth",
+                "Origin": "https://portlandgeneral.com",
+                "Referer": "https://portlandgeneral.com/",
+            },
+            json={
+                "AuthFlow": "USER_PASSWORD_AUTH",
+                "ClientId": _COGNITO_CLIENT_ID,
+                "AuthParameters": {
+                    "USERNAME": username,
+                    "PASSWORD": password,
                 },
-                json={
-                    "email": username,
-                    "password": password,
-                    "returnSecureToken": True,
-                },
-                params={
-                    "key": "AIzaSyDGQGl4SfFoD_KJTo87PboxfNmq89pifqU",  # learned from https://github.com/piekstra/portlandgeneral-api
-                    # If this is incorrect, the resp is 400 and indistinguishable from incorrect username or password
-                },
-                raise_for_status=False,
-            ) as resp
-        ):
-            if resp.status == 400:
-                raise InvalidAuth("Username and password failed")
-            result = await resp.json()
+            },
+            # raise_for_status is left False here because a 400 from Cognito
+            # needs its body inspected (it's how wrong credentials, as
+            # opposed to throttling, are distinguished) before deciding
+            # whether to raise at all.
+            raise_for_status=False,
+        ) as resp:
+            # Cognito responds with Content-Type: application/x-amz-json-1.1,
+            # not application/json, so the content-type check must be skipped.
+            try:
+                result = await resp.json(content_type=None)
+            except (aiohttp.ContentTypeError, ValueError):
+                result = {}
+            if not isinstance(result, dict):
+                result = {}
+            if resp.status == 400 and result.get("__type") in _COGNITO_AUTH_ERROR_TYPES:
+                raise InvalidAuth("Username and password failed: " + str(result.get("message") or result["__type"]))
+            if resp.status in (401, 403):
+                # Cognito's InitiateAuth doesn't normally use 401/403 - a
+                # WAF block or other gateway-level failure could, though,
+                # and Opower.async_login() unconditionally maps any
+                # ClientResponseError with status 401/403 to InvalidAuth
+                # regardless of body. Raise CannotConnect directly here so
+                # an unrecognized 401/403 isn't misreported as bad
+                # credentials.
+                raise CannotConnect(f"Cognito returned {resp.status} without a recognized error body: {result}")
+            # Anything else non-200 (throttling, 5xx, an unparsable body, or
+            # an unrecognized error type) is treated as a connectivity
+            # problem rather than bad credentials: it surfaces here as
+            # aiohttp.ClientResponseError, which Opower.async_login() maps
+            # to CannotConnect.
+            resp.raise_for_status()
+            id_token = (result.get("AuthenticationResult") or {}).get("IdToken")
+            if not id_token:
+                # Cognito can respond with HTTP 200 and a challenge (e.g.
+                # NEW_PASSWORD_REQUIRED, SMS_MFA) instead of tokens when the
+                # account needs an additional step this flow doesn't
+                # support, or rarely with an unparsable/unexpected body.
+                raise InvalidAuth(
+                    "Username and password succeeded, but Cognito did not return a usable token: "
+                    + str(result.get("ChallengeName") or result)
+                )
 
         async with session.post(
-            "https://apix.portlandgeneral.com/pg-token-implicit/token",
+            "https://apix.portlandgeneral.com/pg-token-implicit-aws/token",
             params={
-                "client_id": "VrrKnd0tw2O4zIM6vqHLYn0PxM3ZW2hY",  # learned from https://github.com/piekstra/portlandgeneral-api
+                "client_id": _APIGEE_CLIENT_ID,  # learned from portlandgeneral.com's own web app
                 "response_type": "token",
                 "redirect_uri": "",  # Not sure why this is present with an empty value
             },
             headers={
                 "content-length": "0",
                 "User-Agent": USER_AGENT,
-                "idp_access_token": result.get("idToken"),
+                "idp_access_token": id_token,
             },
             raise_for_status=False,
         ) as resp:
-            result = await resp.json()
-            if resp.status == 500:
+            try:
+                result = await resp.json(content_type=None)
+            except (aiohttp.ContentTypeError, ValueError):
+                result = {}
+            if not isinstance(result, dict):
+                result = {}
+            if resp.status in (400, 401, 403) and "errorResponse" in result:
                 raise InvalidAuth(
-                    "Username and Password Succeeded, but api responded with "
+                    "Username and password succeeded with the identity provider, but PGE's own API rejected "
+                    "the token exchange with "
                     + str(result["errorResponse"])
-                    + ". Code 500 could mean the client_id const is incorrect."
+                    + f". This usually means _APIGEE_CLIENT_ID ({_APIGEE_CLIENT_ID}) is stale and needs updating."
                 )
-            if "errorResponse" in result:
-                raise InvalidAuth("Username and Password Succeeded, but api responded with " + str(result["errorResponse"]))
-            return str(result.get("access_token"))
+            if resp.status in (401, 403):
+                # A 401/403 without the errorResponse body above isn't
+                # necessarily proof the client_id/credentials are wrong -
+                # could be a WAF block or an unrelated gateway failure. As
+                # above, Opower.async_login() maps any ClientResponseError
+                # with status 401/403 to InvalidAuth regardless of body, so
+                # raise CannotConnect directly instead of going through
+                # resp.raise_for_status() here.
+                raise CannotConnect(f"PGE token exchange returned {resp.status} without a recognized error body: {result}")
+            # Anything else non-200 (5xx, an unparsable body) is a
+            # connectivity problem, not something a different password
+            # would fix - let it surface as CannotConnect via
+            # ClientResponseError instead.
+            resp.raise_for_status()
+            access_token = result.get("access_token")
+            if not access_token:
+                raise InvalidAuth(
+                    "Username and password succeeded, but the token exchange response was unexpected: " + str(result)
+                )
+            return str(access_token)

--- a/tests/opower/utilities/test_portlandgeneral.py
+++ b/tests/opower/utilities/test_portlandgeneral.py
@@ -1,0 +1,307 @@
+"""Tests for Portland General Electric (PGE)."""
+
+import os
+import unittest
+from typing import Any
+
+import aiohttp
+from aiohttp import RequestInfo
+from dotenv import load_dotenv
+from multidict import CIMultiDict, CIMultiDictProxy
+from yarl import URL
+
+from opower.exceptions import CannotConnect, InvalidAuth
+from opower.utilities.portlandgeneral import PortlandGeneral
+
+ENV_SECRET_PATH = os.path.join(os.path.dirname(__file__), "../../../.env.secret")
+
+
+class TestPortlandGeneral(unittest.IsolatedAsyncioTestCase):
+    """Test public methods inherited from UtilityBase."""
+
+    def test_name(self) -> None:
+        """Test name."""
+        self.assertEqual("Portland General Electric (PGE)", PortlandGeneral.name())
+
+    def test_subdomain(self) -> None:
+        """Test subdomain."""
+        self.assertEqual("pgn", PortlandGeneral().subdomain())
+
+    def test_timezone(self) -> None:
+        """Test timezone."""
+        self.assertEqual("America/Los_Angeles", PortlandGeneral.timezone())
+
+    async def test_real_login(self) -> None:
+        """Perform a live test against PGE's Cognito and Apigee gateway."""
+        load_dotenv(dotenv_path=ENV_SECRET_PATH)
+
+        username = os.getenv("PORTLANDGENERAL_USERNAME")
+        password = os.getenv("PORTLANDGENERAL_PASSWORD")
+
+        if username is None or password is None:
+            self.skipTest(
+                "Add `PORTLANDGENERAL_USERNAME=` and `PORTLANDGENERAL_PASSWORD=` "
+                "to `.env.secret` to run live PortlandGeneral test."
+            )
+
+        pge = PortlandGeneral()
+        session = aiohttp.ClientSession()
+        self.addAsyncCleanup(session.close)
+
+        access_token = await pge.async_login(session, username, password, {})
+
+        self.assertIsNotNone(access_token)
+        self.assertTrue(len(access_token) > 0)
+
+
+class _MockResponse:
+    """Minimal stand-in for aiohttp.ClientResponse."""
+
+    def __init__(self, *, status: int = 200, payload: Any = None, raise_on_json: Exception | None = None) -> None:
+        self.status = status
+        self._payload = payload
+        self._raise_on_json = raise_on_json
+
+    async def json(self, *, content_type: str | None = "application/json") -> Any:
+        if self._raise_on_json is not None:
+            raise self._raise_on_json
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        if self.status >= 400:
+            raise aiohttp.ClientResponseError(
+                RequestInfo(URL("http://example.com"), "POST", CIMultiDictProxy(CIMultiDict()), URL("http://example.com")),
+                (),
+                status=self.status,
+                message="mock error",
+            )
+
+    async def __aenter__(self) -> "_MockResponse":
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
+
+class _MockSession:
+    """Records requests and returns canned responses keyed by URL."""
+
+    def __init__(self, responses: dict[str, _MockResponse]) -> None:
+        self._responses = responses
+        self.requests: list[dict[str, Any]] = []
+
+    def post(self, url: str, **kwargs: Any) -> _MockResponse:
+        self.requests.append({"url": url, **kwargs})
+        return self._responses[url]
+
+
+COGNITO_URL = "https://cognito-idp.us-west-2.amazonaws.com/"
+TOKEN_URL = "https://apix.portlandgeneral.com/pg-token-implicit-aws/token"  # noqa: S105
+
+
+class TestPortlandGeneralLoginFlow(unittest.IsolatedAsyncioTestCase):
+    """Test the Cognito-based login flow with mocked HTTP responses."""
+
+    async def test_login_success(self) -> None:
+        """A successful Cognito auth followed by a successful token exchange returns the access token."""
+        responses = {
+            COGNITO_URL: _MockResponse(
+                status=200,
+                payload={
+                    "AuthenticationResult": {
+                        "AccessToken": "cognito_access_token",
+                        "IdToken": "cognito_id_token",
+                        "RefreshToken": "cognito_refresh_token",
+                        "TokenType": "Bearer",
+                        "ExpiresIn": 3600,
+                    }
+                },
+            ),
+            TOKEN_URL: _MockResponse(status=200, payload={"access_token": "pge_access_token", "client_id": "test"}),
+        }
+        session = _MockSession(responses)
+
+        token = await PortlandGeneral().async_login(session, "user", "pass", {})  # type: ignore[arg-type]
+
+        self.assertEqual(token, "pge_access_token")
+
+        cognito_request = next(r for r in session.requests if r["url"] == COGNITO_URL)
+        self.assertEqual(cognito_request["json"]["AuthParameters"]["USERNAME"], "user")
+        self.assertEqual(cognito_request["json"]["AuthParameters"]["PASSWORD"], "pass")
+        self.assertEqual(cognito_request["headers"]["X-Amz-Target"], "AWSCognitoIdentityProviderService.InitiateAuth")
+
+        token_request = next(r for r in session.requests if r["url"] == TOKEN_URL)
+        self.assertEqual(token_request["headers"]["idp_access_token"], "cognito_id_token")
+
+    async def test_login_wrong_credentials_raises_invalid_auth(self) -> None:
+        """A Cognito NotAuthorizedException (wrong username/password) raises InvalidAuth."""
+        responses = {
+            COGNITO_URL: _MockResponse(
+                status=400,
+                payload={"__type": "NotAuthorizedException", "message": "Incorrect username or password."},
+            ),
+        }
+        session = _MockSession(responses)
+
+        with self.assertRaises(InvalidAuth):
+            await PortlandGeneral().async_login(session, "user", "wrong", {})  # type: ignore[arg-type]
+
+    async def test_login_cognito_5xx_raises_client_response_error(self) -> None:
+        """A Cognito 5xx (outage) raises ClientResponseError, not InvalidAuth, so it maps to CannotConnect."""
+        responses = {
+            COGNITO_URL: _MockResponse(status=500, payload={"__type": "InternalErrorException", "message": "oops"}),
+        }
+        session = _MockSession(responses)
+
+        with self.assertRaises(aiohttp.ClientResponseError):
+            await PortlandGeneral().async_login(session, "user", "pass", {})  # type: ignore[arg-type]
+
+    async def test_login_cognito_throttling_raises_client_response_error(self) -> None:
+        """Cognito throttling (400 but not a credentials error type) raises ClientResponseError, not InvalidAuth."""
+        responses = {
+            COGNITO_URL: _MockResponse(status=400, payload={"__type": "TooManyRequestsException", "message": "Rate exceeded"}),
+        }
+        session = _MockSession(responses)
+
+        with self.assertRaises(aiohttp.ClientResponseError):
+            await PortlandGeneral().async_login(session, "user", "pass", {})  # type: ignore[arg-type]
+
+    async def test_login_cognito_401_without_error_type_raises_cannot_connect(self) -> None:
+        """A 401 from Cognito with no recognized error body raises CannotConnect, not InvalidAuth.
+
+        Opower.async_login() maps any ClientResponseError with status 401/403 to InvalidAuth
+        regardless of body, so an unrecognized 401 (e.g. a WAF block) must not be allowed to
+        reach resp.raise_for_status() here or it would get misreported as bad credentials.
+        """
+        responses = {
+            COGNITO_URL: _MockResponse(status=401, payload={"message": "Forbidden by WAF"}),
+        }
+        session = _MockSession(responses)
+
+        with self.assertRaises(CannotConnect):
+            await PortlandGeneral().async_login(session, "user", "pass", {})  # type: ignore[arg-type]
+
+    async def test_login_challenge_raises_invalid_auth(self) -> None:
+        """A Cognito challenge (e.g. NEW_PASSWORD_REQUIRED) instead of tokens raises InvalidAuth, not KeyError."""
+        responses = {
+            COGNITO_URL: _MockResponse(
+                status=200,
+                payload={"ChallengeName": "NEW_PASSWORD_REQUIRED", "ChallengeParameters": {}, "Session": "abc"},
+            ),
+        }
+        session = _MockSession(responses)
+
+        with self.assertRaises(InvalidAuth):
+            await PortlandGeneral().async_login(session, "user", "pass", {})  # type: ignore[arg-type]
+
+    async def test_login_null_id_token_raises_invalid_auth(self) -> None:
+        """AuthenticationResult present but with a null/missing IdToken raises InvalidAuth, not TypeError."""
+        responses = {
+            COGNITO_URL: _MockResponse(
+                status=200,
+                payload={"AuthenticationResult": {"IdToken": None, "AccessToken": "at"}},
+            ),
+        }
+        session = _MockSession(responses)
+
+        with self.assertRaises(InvalidAuth):
+            await PortlandGeneral().async_login(session, "user", "pass", {})  # type: ignore[arg-type]
+
+    async def test_token_exchange_failure_raises_invalid_auth(self) -> None:
+        """If Cognito succeeds but PGE's own gateway rejects the token exchange, InvalidAuth is raised."""
+        responses = {
+            COGNITO_URL: _MockResponse(
+                status=200,
+                payload={"AuthenticationResult": {"IdToken": "cognito_id_token"}},
+            ),
+            TOKEN_URL: _MockResponse(
+                status=401,
+                payload={"errorResponse": {"code": "401", "message": "api key is invalid"}},
+            ),
+        }
+        session = _MockSession(responses)
+
+        with self.assertRaises(InvalidAuth):
+            await PortlandGeneral().async_login(session, "user", "pass", {})  # type: ignore[arg-type]
+
+    async def test_token_exchange_403_without_error_response_raises_cannot_connect(self) -> None:
+        """A 403 from the token exchange with no recognized errorResponse body raises CannotConnect.
+
+        Same reasoning as the Cognito 401 case: a bare 403 (e.g. a WAF block at PGE's gateway)
+        must not fall through to resp.raise_for_status(), since Opower.async_login() would map
+        that unconditionally to InvalidAuth regardless of body content.
+        """
+        responses = {
+            COGNITO_URL: _MockResponse(
+                status=200,
+                payload={"AuthenticationResult": {"IdToken": "cognito_id_token"}},
+            ),
+            TOKEN_URL: _MockResponse(status=403, payload={"message": "Forbidden by WAF"}),
+        }
+        session = _MockSession(responses)
+
+        with self.assertRaises(CannotConnect):
+            await PortlandGeneral().async_login(session, "user", "pass", {})  # type: ignore[arg-type]
+
+    async def test_token_exchange_non_json_response_raises_client_response_error(self) -> None:
+        """A non-JSON (e.g. HTML gateway error page) token-exchange response raises ClientResponseError.
+
+        Not a raw JSON decode error, and not InvalidAuth - a 502 with an unparsable body is a
+        connectivity problem, not proof the credentials are wrong.
+        """
+        responses = {
+            COGNITO_URL: _MockResponse(
+                status=200,
+                payload={"AuthenticationResult": {"IdToken": "cognito_id_token"}},
+            ),
+            TOKEN_URL: _MockResponse(status=502, raise_on_json=ValueError("Expecting value: line 1 column 1")),
+        }
+        session = _MockSession(responses)
+
+        with self.assertRaises(aiohttp.ClientResponseError):
+            await PortlandGeneral().async_login(session, "user", "pass", {})  # type: ignore[arg-type]
+
+    async def test_token_exchange_missing_access_token_raises_invalid_auth(self) -> None:
+        """A 200 response missing access_token raises InvalidAuth instead of returning the string "None"."""
+        responses = {
+            COGNITO_URL: _MockResponse(
+                status=200,
+                payload={"AuthenticationResult": {"IdToken": "cognito_id_token"}},
+            ),
+            TOKEN_URL: _MockResponse(status=200, payload={"client_id": "test"}),
+        }
+        session = _MockSession(responses)
+
+        with self.assertRaises(InvalidAuth):
+            await PortlandGeneral().async_login(session, "user", "pass", {})  # type: ignore[arg-type]
+
+    async def test_token_exchange_null_access_token_raises_invalid_auth(self) -> None:
+        """A 200 response with access_token explicitly null raises InvalidAuth, not the literal string "None"."""
+        responses = {
+            COGNITO_URL: _MockResponse(
+                status=200,
+                payload={"AuthenticationResult": {"IdToken": "cognito_id_token"}},
+            ),
+            TOKEN_URL: _MockResponse(status=200, payload={"access_token": None, "client_id": "test"}),
+        }
+        session = _MockSession(responses)
+
+        with self.assertRaises(InvalidAuth):
+            await PortlandGeneral().async_login(session, "user", "pass", {})  # type: ignore[arg-type]
+
+    async def test_token_exchange_500_raises_client_response_error(self) -> None:
+        """A 500 from the token exchange (server-side outage) raises ClientResponseError, not InvalidAuth."""
+        responses = {
+            COGNITO_URL: _MockResponse(
+                status=200,
+                payload={"AuthenticationResult": {"IdToken": "cognito_id_token"}},
+            ),
+            TOKEN_URL: _MockResponse(
+                status=500,
+                payload={"errorResponse": {"code": "500", "message": "server error"}},
+            ),
+        }
+        session = _MockSession(responses)
+
+        with self.assertRaises(aiohttp.ClientResponseError):
+            await PortlandGeneral().async_login(session, "user", "pass", {})  # type: ignore[arg-type]


### PR DESCRIPTION
## Apology
This is my first interaction with a repo that uses Copilot review, and it was quite noisy.  The commit itself is squashed, and I apologize for the back and forth in the conversation.  This initial comment and the last (https://github.com/tronikos/opower/pull/205#issuecomment-4984958893) should summarize the conversation well.

## Problem
PGE's opower integration has been broken since ~mid-June 2026 with "Invalid Authentication" on every login attempt, even with correct credentials — reported in [home-assistant/core#173778](https://github.com/home-assistant/core/issues/173778) with several "me too"s and no working diagnosis yet.

## Root cause
PGE didn't just rotate a key — they replaced their identity provider outright, from Firebase to **AWS Cognito**. The old `async_login()` posted to `identitytoolkit.googleapis.com` (Firebase) and exchanged the result at `apix.portlandgeneral.com/pg-token-implicit/token` using a hardcoded `client_id`. That endpoint now rejects that `client_id` with `401 {"errorResponse":{"message":"api key is invalid"}}` — before checking any actual credentials, which is why the failure looks identical for every user regardless of their password.

Confirmed via live network capture during a real login on portlandgeneral.com: PGE now authenticates through `cognito-idp.us-west-2.amazonaws.com` (User Pool `us-west-2_rnEzd20tN`, App Client ID `4q9nbgmi0gcks5t7d6fkhubfnm`), then exchanges the resulting Cognito ID token at a parallel `apix.portlandgeneral.com/pg-token-implicit-aws/token` endpoint (note the `-aws` suffix) with a new `client_id`.

## Fix
- Step 1: Cognito `InitiateAuth` (`USER_PASSWORD_AUTH`) instead of Firebase `signInWithPassword`. Cognito responds with `Content-Type: application/x-amz-json-1.1`, not `application/json`, so aiohttp's content-type check is skipped.
- Step 2: point at the new `-aws` token endpoint with the new `client_id` (extracted to a named `_APIGEE_CLIENT_ID` constant).
- Error classification only treats a response as `InvalidAuth` (bad credentials) when the body actually says so — a recognized Cognito error type on the first call, or a parsed `errorResponse` on 400/401/403 on the second. Everything else non-200 (throttling, 5xx, an unparsable body) surfaces as `aiohttp.ClientResponseError`, which `Opower.async_login()` already maps to `CannotConnect` — so a PGE/Cognito outage isn't misreported to users as "your password is wrong."
- Both steps use null-safe extraction (`.get()` with truthiness checks, not just `in` membership), so a response with a present-but-null field can't slip through and get stringified into the literal text `"None"`, and a malformed response can't crash with `TypeError`.

## Testing
- Added `tests/opower/utilities/test_portlandgeneral.py`: mocked coverage for success, wrong credentials, Cognito challenges (e.g. `NEW_PASSWORD_REQUIRED`), 5xx/throttling on both calls, non-JSON and null-valued response bodies, plus a live test gated behind `.env.secret` following this repo's existing convention (see `test_scl.py`, `test_smud.py`).
- **Verified live against production PGE endpoints:** a real account's correct credentials complete both login steps and return a valid access token; wrong credentials against the real Cognito endpoint correctly raise `InvalidAuth`.
- Full suite (74 tests) + ruff + mypy clean.
- **Not verified:** whether the returned access token is accepted by `pgn.opower.com`'s own usage-data API — the actual data Home Assistant sensors depend on. At test time, `pgn.opower.com` was returning `503` ("We're doing some work to update this site") for *all* requests to that subdomain, authenticated or not — confirmed specific to PGE's tenant (another utility's opower.com subdomain responded normally in the same window), so this looks like a separate, unrelated outage rather than anything this fix touches.

If anyone hitting this issue can confirm usage data loads in Home Assistant with this branch once `pgn.opower.com` is healthy again, that would close the remaining gap.