### PR TITLE
Add Clark Public Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This library is used by the [Opower integration in Home Assistant](https://www.h
   - Southwestern Electric Power Company (SWEPCO)
 - Burbank Water and Power (BWP)
 - City of Austin Utilities
+- Clark Public Utilities
 - Consolidated Edison (ConEd) and subsidiaries
   - Orange & Rockland Utilities (ORU)
 - Duquesne Light Company (DQE)

--- a/src/opower/utilities/clarkpublicutilities.py
+++ b/src/opower/utilities/clarkpublicutilities.py
@@ -1,0 +1,56 @@
+"""Clark Public Utilities."""
+
+from typing import Any
+
+import aiohttp
+
+from ..const import USER_AGENT
+from .base import UtilityBase
+
+
+class ClarkPublicUtilities(UtilityBase):
+    """Clark Public Utilities.
+
+    Serves Clark County, Washington. Uses the Opower portal hosted directly
+    at ``clrk.opower.com`` (no separate corporate-site SSO hop precedes it -
+    the sign-in wall lives on the opower.com domain itself, at
+    ``clrk.opower.com/ei/x/sign-in-wall``). This follows the same
+    user-account-control-v1 signin pattern used by other utilities whose
+    portal is directly opower-hosted, e.g. Burbank Water and Power (bwp.py),
+    Glendale Water and Power (glendalewaterandpower.py), and Rhode Island
+    Energy (rienergy.py): a JSON POST of the credentials sets an auth cookie,
+    and no bearer token is returned or needed for subsequent requests.
+    """
+
+    @staticmethod
+    def name() -> str:
+        """Distinct recognizable name of the utility."""
+        return "Clark Public Utilities"
+
+    def subdomain(self) -> str:
+        """Return the opower.com subdomain for this utility."""
+        return "clrk"
+
+    @staticmethod
+    def timezone() -> str:
+        """Return the timezone."""
+        return "America/Los_Angeles"
+
+    async def async_login(
+        self,
+        session: aiohttp.ClientSession,
+        username: str,
+        password: str,
+        login_data: dict[str, Any],
+    ) -> None:
+        """Login to the utility website."""
+        async with session.post(
+            "https://clrk.opower.com/ei/edge/apis/user-account-control-v1/cws/v1/clrk/account/signin",
+            json={
+                "username": username,
+                "password": password,
+            },
+            headers={"User-Agent": USER_AGENT},
+            raise_for_status=True,
+        ) as _:
+            pass

--- a/tests/opower/utilities/test_clarkpublicutilities.py
+++ b/tests/opower/utilities/test_clarkpublicutilities.py
@@ -1,0 +1,55 @@
+"""Tests for Clark Public Utilities."""
+
+import os
+import unittest
+
+import aiohttp
+from dotenv import load_dotenv
+
+from opower.utilities.clarkpublicutilities import ClarkPublicUtilities
+
+ENV_SECRET_PATH = os.path.join(os.path.dirname(__file__), "../../../.env.secret")
+
+
+class TestClarkPublicUtilities(unittest.IsolatedAsyncioTestCase):
+    """Test public methods inherited from UtilityBase."""
+
+    def test_name(self) -> None:
+        """Test name."""
+        clark = ClarkPublicUtilities()
+
+        self.assertEqual("Clark Public Utilities", clark.name())
+
+    def test_subdomain(self) -> None:
+        """Test subdomain."""
+        clark = ClarkPublicUtilities()
+
+        self.assertEqual("clrk", clark.subdomain())
+
+    def test_timezone(self) -> None:
+        """Test timezone."""
+        clark = ClarkPublicUtilities()
+
+        self.assertEqual("America/Los_Angeles", clark.timezone())
+
+    async def test_real_login(self) -> None:
+        """Perform a live test against the Clark Public Utilities Opower website."""
+        load_dotenv(dotenv_path=ENV_SECRET_PATH)
+
+        username = os.getenv("CLARK_PUBLIC_UTILITIES_USERNAME")
+        password = os.getenv("CLARK_PUBLIC_UTILITIES_PASSWORD")
+
+        if username is None or password is None:
+            self.skipTest(
+                "Add `CLARK_PUBLIC_UTILITIES_USERNAME=` and `CLARK_PUBLIC_UTILITIES_PASSWORD=` "
+                "to `.env.secret` to run live Clark Public Utilities test."
+            )
+
+        clark = ClarkPublicUtilities()
+        session = aiohttp.ClientSession()
+        self.addCleanup(session.close)
+
+        # Clark authorizes via a session cookie set by the signin endpoint and
+        # returns no bearer token, so async_login returns None on success. This
+        # should simply not raise an exception with valid credentials.
+        await clark.async_login(session, username, password, {})


### PR DESCRIPTION
Adds support for Clark Public Utilities (Clark County, Washington), which uses the Opower EI portal at clrk.opower.com.

Login follows the same directly-opower-hosted pattern as Burbank Water and Power, Glendale Water and Power, and Rhode Island Energy: a JSON POST of the credentials to the user-account-control-v1 signin endpoint sets a session cookie, and no bearer token is returned.

Tested against a live account: login succeeds, the account is discovered via multi-account-v1/customers, and monthly billing usage and cost statistics load correctly in Home Assistant. The account is billing resolution / non-AMI, so only bill-level data is available (no interval data or bill forecast), which is expected for this utility.

Changes:
- Add src/opower/utilities/clarkpublicutilities.py
- Add tests/opower/utilities/test_clarkpublicutilities.py
- Add Clark Public Utilities to the README supported utilities list
