### PR TITLE
Add support for AES Indiana

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This library is used by the [Opower integration in Home Assistant](https://www.h
 
 ## Supported Utilities
 
+- AES Indiana
 - American Electric Power (AEP) subsidiaries
   - AEP Ohio
   - AEP Texas

--- a/src/opower/utilities/aesindiana.py
+++ b/src/opower/utilities/aesindiana.py
@@ -34,7 +34,6 @@
 # `python -m opower --utility aesindiana --username you@example.com -v`
 
 import logging
-from html.parser import HTMLParser
 from typing import Any
 
 import aiohttp
@@ -43,73 +42,12 @@ from yarl import URL
 from ..const import USER_AGENT
 from ..exceptions import CannotConnect, InvalidAuth
 from .base import UtilityBase
+from .helpers import parse_forms
 
 _LOGGER = logging.getLogger(__name__)
 
 _MAX_HOPS = 15
 _LOGIN_URL = URL("https://aesi.opower.com/ei/x/dashboard")
-
-
-class Form:
-    """A parsed HTML form: its action and the fields a browser would submit."""
-
-    def __init__(self, action: str | None) -> None:
-        """Initialize."""
-        self.action = action
-        self.inputs: dict[str, str] = {}
-        self.has_password = False
-        self._submit_seen = False
-
-    def add_input(self, attrs: dict[str, str | None]) -> None:
-        """Add an input field, applying browser form-submission rules."""
-        name = attrs.get("name")
-        input_type = (attrs.get("type") or "text").lower()
-        if input_type == "password":
-            self.has_password = True
-        if not name:
-            return
-        # Match what a browser submits: skip non-submitting controls,
-        # unchecked boxes, and all but the activated (first) submit button.
-        if input_type in ("button", "reset", "image"):
-            return
-        if input_type in ("checkbox", "radio") and "checked" not in attrs:
-            return
-        if input_type == "submit":
-            if self._submit_seen:
-                return
-            self._submit_seen = True
-        self.inputs[name] = attrs.get("value") or ""
-
-
-class FormsParser(HTMLParser):
-    """HTML parser that captures every form on the page with its input fields."""
-
-    def __init__(self) -> None:
-        """Initialize."""
-        super().__init__()
-        self.forms: list[Form] = []
-        self._current: Form | None = None
-
-    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
-        """Track forms and collect their inputs."""
-        attrs_dict = dict(attrs)
-        if tag == "form":
-            self._current = Form(attrs_dict.get("action"))
-            self.forms.append(self._current)
-        elif tag == "input" and self._current is not None:
-            self._current.add_input(attrs_dict)
-
-    def handle_endtag(self, tag: str) -> None:
-        """Close the current form."""
-        if tag == "form":
-            self._current = None
-
-
-def _parse_forms(html: str) -> list[Form]:
-    """Parse all forms out of an HTML page."""
-    parser = FormsParser()
-    parser.feed(html)
-    return parser.forms
 
 
 def _is_opower(url: URL) -> bool:
@@ -169,7 +107,7 @@ async def _request(
 
 def _is_allowed_sso_host(url: URL) -> bool:
     """Check an SSO form target before posting assertion material to it."""
-    return (
+    return url.scheme == "https" and (
         url.host == "myaccount.aesindiana.com"
         or (url.host is not None and url.host.endswith(".identity.oraclecloud.com"))
         or _is_opower(url)
@@ -182,12 +120,12 @@ async def _complete_sso(session: aiohttp.ClientSession, url: URL, html: str) -> 
         if _is_opower(url):
             return
         form = next(
-            (f for f in _parse_forms(html) if "SAMLResponse" in f.inputs or "OCIS_REQ_SP" in f.inputs),
+            (f for f in parse_forms(html) if "SAMLResponse" in f.inputs or "OCIS_REQ_SP" in f.inputs),
             None,
         )
         if form is None:
             # Served the login page again => bad credentials.
-            if any(f.has_password for f in _parse_forms(html)):
+            if any(f.has_password for f in parse_forms(html)):
                 raise InvalidAuth("Invalid AES Indiana credentials")
             raise CannotConnect(f"Unexpected page during AES Indiana SSO: {_redact(url)}")
         # An empty/missing action means "submit to the current URL".
@@ -208,8 +146,7 @@ class AESIndiana(UtilityBase):
         """Return the name of the utility."""
         return "AES Indiana"
 
-    @staticmethod
-    def subdomain() -> str:
+    def subdomain(self) -> str:
         """Return the opower.com subdomain for this utility."""
         return "aesi"
 
@@ -249,14 +186,22 @@ class AESIndiana(UtilityBase):
 
         # Step 2: if we are on the login page, POST the login form with the
         # fields it served (all scraped at once), plus the credentials.
-        login_form = next((f for f in _parse_forms(html) if f.has_password), None)
+        login_form = next((f for f in parse_forms(html) if f.has_password), None)
         if login_form is not None:
+            filled = set()
             for name in list(login_form.inputs):
                 if "username" in name.lower():
                     login_form.inputs[name] = username
+                    filled.add("username")
                 elif "password" in name.lower():
                     login_form.inputs[name] = password
-            url, html = await _request(session, "POST", url, login_form.inputs, auth_request=True, referer=url)
+                    filled.add("password")
+            if filled != {"username", "password"}:
+                raise CannotConnect("Could not find the username/password fields on the AES Indiana login page")
+            # Post to the form's action like a browser would (relative to the
+            # page URL); an empty/missing action means the current URL.
+            action = url.join(URL(login_form.action, encoded=True)) if login_form.action else url
+            url, html = await _request(session, "POST", action, login_form.inputs, auth_request=True, referer=url)
 
         # Step 3/4: follow auto-submit forms until we land back on opower.
         await _complete_sso(session, url, html)

--- a/src/opower/utilities/aesindiana.py
+++ b/src/opower/utilities/aesindiana.py
@@ -21,6 +21,10 @@
 # 4. POST that form; IDCS then redirects back to aesi.opower.com which sets
 #    the session cookies.
 #
+# On re-login: a still-valid opower session is detected with an API call and
+# skips the SSO entirely; a still-valid myaccount session skips the login
+# form (step 1 lands directly on the SAML auto-submit form).
+#
 # NOTE: redirects are followed manually with yarl URL(encoded=True) because
 # the SAMLRequest query string is signed; aiohttp's default redirect
 # re-quoting alters the percent-encoding and the signature fails to verify
@@ -43,26 +47,79 @@ from .base import UtilityBase
 _LOGGER = logging.getLogger(__name__)
 
 _MAX_HOPS = 15
+_LOGIN_URL = URL("https://aesi.opower.com/ei/x/dashboard")
 
 
-class FormParser(HTMLParser):
-    """HTML parser that captures a form's action and ALL of its input fields at once."""
+class Form:
+    """A parsed HTML form: its action and the fields a browser would submit."""
+
+    def __init__(self, action: str | None) -> None:
+        """Initialize."""
+        self.action = action
+        self.inputs: dict[str, str] = {}
+        self.has_password = False
+        self._submit_seen = False
+
+    def add_input(self, attrs: dict[str, str | None]) -> None:
+        """Add an input field, applying browser form-submission rules."""
+        name = attrs.get("name")
+        input_type = (attrs.get("type") or "text").lower()
+        if input_type == "password":
+            self.has_password = True
+        if not name:
+            return
+        # Match what a browser submits: skip non-submitting controls,
+        # unchecked boxes, and all but the activated (first) submit button.
+        if input_type in ("button", "reset", "image"):
+            return
+        if input_type in ("checkbox", "radio") and "checked" not in attrs:
+            return
+        if input_type == "submit":
+            if self._submit_seen:
+                return
+            self._submit_seen = True
+        self.inputs[name] = attrs.get("value") or ""
+
+
+class FormsParser(HTMLParser):
+    """HTML parser that captures every form on the page with its input fields."""
 
     def __init__(self) -> None:
         """Initialize."""
         super().__init__()
-        self.action: str | None = None
-        self.inputs: dict[str, str] = {}
+        self.forms: list[Form] = []
+        self._current: Form | None = None
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
-        """Capture the first form's action and every named input's value."""
+        """Track forms and collect their inputs."""
         attrs_dict = dict(attrs)
-        if tag == "form" and self.action is None:
-            self.action = attrs_dict.get("action")
-        if tag == "input":
-            name = attrs_dict.get("name")
-            if name:
-                self.inputs[name] = attrs_dict.get("value") or ""
+        if tag == "form":
+            self._current = Form(attrs_dict.get("action"))
+            self.forms.append(self._current)
+        elif tag == "input" and self._current is not None:
+            self._current.add_input(attrs_dict)
+
+    def handle_endtag(self, tag: str) -> None:
+        """Close the current form."""
+        if tag == "form":
+            self._current = None
+
+
+def _parse_forms(html: str) -> list[Form]:
+    """Parse all forms out of an HTML page."""
+    parser = FormsParser()
+    parser.feed(html)
+    return parser.forms
+
+
+def _is_opower(url: URL) -> bool:
+    """Return True if the URL is on the AES Indiana opower portal."""
+    return url.host == "aesi.opower.com"
+
+
+def _redact(url: URL) -> str:
+    """Return the URL without its query string (may carry signed SSO material)."""
+    return f"{url.host}{url.path}"
 
 
 async def _request(
@@ -70,32 +127,77 @@ async def _request(
     method: str,
     url: URL,
     data: dict[str, str] | None = None,
+    auth_request: bool = False,
+    referer: URL | None = None,
 ) -> tuple[URL, str]:
     """Make a request following redirects manually, preserving exact URL encoding.
 
+    With auth_request=True, a 401/403 response raises InvalidAuth.
     Returns the final URL and response body.
     """
+    headers = {"User-Agent": USER_AGENT}
+    if referer is not None:
+        headers["Referer"] = str(referer)
     for _ in range(_MAX_HOPS):
         async with session.request(
             method,
             url,
             data=data,
-            headers={"User-Agent": USER_AGENT},
+            headers=headers,
             allow_redirects=False,
-            raise_for_status=True,
+            raise_for_status=False,
         ) as resp:
             if resp.status in (301, 302, 303, 307, 308):
                 location = resp.headers.get("Location")
                 if not location:
                     raise CannotConnect("Redirect without Location header")
-                _LOGGER.debug("Redirect -> %s", location)
-                url = url.join(URL(location, encoded=True))
-                if resp.status != 307:
+                try:
+                    url = url.join(URL(location, encoded=True))
+                except ValueError as err:
+                    raise CannotConnect("Invalid redirect target during AES Indiana login") from err
+                _LOGGER.debug("Redirect -> %s", _redact(url))
+                if resp.status not in (307, 308):
                     method = "GET"
                     data = None
                 continue
+            if auth_request and resp.status in (401, 403):
+                raise InvalidAuth("Invalid AES Indiana credentials")
+            resp.raise_for_status()
             return resp.real_url, await resp.text()
     raise CannotConnect("Too many redirects during AES Indiana login")
+
+
+def _is_allowed_sso_host(url: URL) -> bool:
+    """Check an SSO form target before posting assertion material to it."""
+    return (
+        url.host == "myaccount.aesindiana.com"
+        or (url.host is not None and url.host.endswith(".identity.oraclecloud.com"))
+        or _is_opower(url)
+    )
+
+
+async def _complete_sso(session: aiohttp.ClientSession, url: URL, html: str) -> None:
+    """Follow SSO auto-submit forms (SAMLResponse to IDCS /fed/v1/sp/sso, etc.) until back on opower."""
+    for _ in range(5):
+        if _is_opower(url):
+            return
+        form = next(
+            (f for f in _parse_forms(html) if "SAMLResponse" in f.inputs or "OCIS_REQ_SP" in f.inputs),
+            None,
+        )
+        if form is None:
+            # Served the login page again => bad credentials.
+            if any(f.has_password for f in _parse_forms(html)):
+                raise InvalidAuth("Invalid AES Indiana credentials")
+            raise CannotConnect(f"Unexpected page during AES Indiana SSO: {_redact(url)}")
+        # An empty/missing action means "submit to the current URL".
+        action = url.join(URL(form.action, encoded=True)) if form.action else url
+        if not _is_allowed_sso_host(action):
+            raise CannotConnect(f"Unexpected AES Indiana SSO form target: {_redact(action)}")
+        _LOGGER.debug("Auto-submitting SSO form to %s", _redact(action))
+        url, html = await _request(session, "POST", action, form.inputs)
+    if not _is_opower(url):
+        raise CannotConnect("AES Indiana SSO did not reach opower.com")
 
 
 class AESIndiana(UtilityBase):
@@ -116,49 +218,45 @@ class AESIndiana(UtilityBase):
         """Return the timezone."""
         return "America/Indiana/Indianapolis"
 
-    @staticmethod
     async def async_login(
+        self,
         session: aiohttp.ClientSession,
         username: str,
         password: str,
         login_data: dict[str, Any],
     ) -> None:
         """Login via myaccount.aesindiana.com and ride the SAML SSO into opower."""
-        # Step 1: start at the opower dashboard; redirects end on the
-        # myaccount login page carrying the SAML request in ReturnURL.
-        login_page_url, login_html = await _request(session, "GET", URL("https://aesi.opower.com/ei/x/dashboard"))
-        if login_page_url.host != "myaccount.aesindiana.com":
-            raise CannotConnect(f"Unexpected login redirect target: {login_page_url}")
+        # Step 1: start at the opower dashboard. With a valid opower session
+        # this lands right back on opower.com; otherwise redirects end on
+        # myaccount (either the login page, or - if the myaccount session is
+        # still valid - directly on the SAML auto-submit form).
+        url, html = await _request(session, "GET", _LOGIN_URL)
+        if _is_opower(url):
+            # Confirm the session actually works before trusting it.
+            try:
+                async with session.get(
+                    "https://aesi.opower.com/ei/edge/apis/multi-account-v1/cws/aesi/customers",
+                    headers={"User-Agent": USER_AGENT},
+                    raise_for_status=True,
+                ):
+                    return
+            except aiohttp.ClientResponseError:
+                _LOGGER.debug("Existing opower session is stale; logging in again")
+                session.cookie_jar.clear(lambda c: c["domain"].endswith("opower.com"))
+                url, html = await _request(session, "GET", _LOGIN_URL)
+        if url.host != "myaccount.aesindiana.com":
+            raise CannotConnect(f"Unexpected login redirect target: {_redact(url)}")
 
-        # Step 2: POST the ASP.NET login form with every field it served.
-        login_form = FormParser()
-        login_form.feed(login_html)
-        password_field_found = False
-        for name in list(login_form.inputs):
-            if name.endswith("$UserName"):
-                login_form.inputs[name] = username
-            elif name.endswith("$Password"):
-                login_form.inputs[name] = password
-                password_field_found = True
-        if not password_field_found:
-            raise CannotConnect("Could not find the AES Indiana login form")
+        # Step 2: if we are on the login page, POST the login form with the
+        # fields it served (all scraped at once), plus the credentials.
+        login_form = next((f for f in _parse_forms(html) if f.has_password), None)
+        if login_form is not None:
+            for name in list(login_form.inputs):
+                if "username" in name.lower():
+                    login_form.inputs[name] = username
+                elif "password" in name.lower():
+                    login_form.inputs[name] = password
+            url, html = await _request(session, "POST", url, login_form.inputs, auth_request=True, referer=url)
 
-        url, html = await _request(session, "POST", login_page_url, login_form.inputs)
-
-        # Step 3/4: follow auto-submit forms (SAMLResponse to IDCS
-        # /fed/v1/sp/sso, etc.) until we land back on opower with a session.
-        for _ in range(4):
-            if url.host is not None and url.host.endswith("opower.com"):
-                return
-            form = FormParser()
-            form.feed(html)
-            if not form.action or not ("SAMLResponse" in form.inputs or "OCIS_REQ_SP" in form.inputs):
-                # Still on myaccount with a password field => bad credentials.
-                if any(name.endswith("$Password") for name in form.inputs):
-                    raise InvalidAuth("Invalid AES Indiana credentials")
-                raise CannotConnect("Unexpected page during AES Indiana SSO")
-            action = url.join(URL(form.action, encoded=True))
-            _LOGGER.debug("Auto-submitting SSO form to %s", action)
-            url, html = await _request(session, "POST", action, form.inputs)
-
-        raise CannotConnect("AES Indiana SSO did not reach opower.com")
+        # Step 3/4: follow auto-submit forms until we land back on opower.
+        await _complete_sso(session, url, html)

--- a/src/opower/utilities/aesindiana.py
+++ b/src/opower/utilities/aesindiana.py
@@ -1,0 +1,164 @@
+"""AES Indiana (formerly Indianapolis Power & Light)."""
+
+#
+# AES Indiana is the electric utility for Indianapolis, Indiana.
+#
+# https://www.aesindiana.com
+# Customer portal: https://myaccount.aesindiana.com (ASP.NET WebForms)
+# Usage portal ("PowerView"): https://aesi.opower.com/ei/x/dashboard
+#
+# Login flow (all discoverable anonymously by following redirects from the
+# dashboard URL):
+# 1. GET https://aesi.opower.com/ei/x/dashboard
+#    -> /ei/app/api/authenticate
+#    -> Oracle IDCS /oauth2/v1/authorize (client_id=Opower_SSO_aesi_prod_APPID)
+#    -> IDCS /fed/v1/user/request/login
+#    -> https://myaccount.aesindiana.com/SAML/ssoservice.aspx?SAMLRequest=...
+#    -> myaccount login page (ReturnURL preserves the SAML request)
+# 2. POST the ASP.NET login form (all hidden fields + credentials).
+# 3. myaccount answers the SAML request with an auto-submit form
+#    (SAMLResponse) whose action is IDCS /fed/v1/sp/sso.
+# 4. POST that form; IDCS then redirects back to aesi.opower.com which sets
+#    the session cookies.
+#
+# NOTE: redirects are followed manually with yarl URL(encoded=True) because
+# the SAMLRequest query string is signed; aiohttp's default redirect
+# re-quoting alters the percent-encoding and the signature fails to verify
+# ("The authn request signature failed to verify.").
+#
+# Test with:
+# `python -m opower --utility aesindiana --username you@example.com -v`
+
+import logging
+from html.parser import HTMLParser
+from typing import Any
+
+import aiohttp
+from yarl import URL
+
+from ..const import USER_AGENT
+from ..exceptions import CannotConnect, InvalidAuth
+from .base import UtilityBase
+
+_LOGGER = logging.getLogger(__name__)
+
+_MAX_HOPS = 15
+
+
+class FormParser(HTMLParser):
+    """HTML parser that captures a form's action and ALL of its input fields at once."""
+
+    def __init__(self) -> None:
+        """Initialize."""
+        super().__init__()
+        self.action: str | None = None
+        self.inputs: dict[str, str] = {}
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        """Capture the first form's action and every named input's value."""
+        attrs_dict = dict(attrs)
+        if tag == "form" and self.action is None:
+            self.action = attrs_dict.get("action")
+        if tag == "input":
+            name = attrs_dict.get("name")
+            if name:
+                self.inputs[name] = attrs_dict.get("value") or ""
+
+
+async def _request(
+    session: aiohttp.ClientSession,
+    method: str,
+    url: URL,
+    data: dict[str, str] | None = None,
+) -> tuple[URL, str]:
+    """Make a request following redirects manually, preserving exact URL encoding.
+
+    Returns the final URL and response body.
+    """
+    for _ in range(_MAX_HOPS):
+        async with session.request(
+            method,
+            url,
+            data=data,
+            headers={"User-Agent": USER_AGENT},
+            allow_redirects=False,
+            raise_for_status=True,
+        ) as resp:
+            if resp.status in (301, 302, 303, 307, 308):
+                location = resp.headers.get("Location")
+                if not location:
+                    raise CannotConnect("Redirect without Location header")
+                _LOGGER.debug("Redirect -> %s", location)
+                url = url.join(URL(location, encoded=True))
+                if resp.status != 307:
+                    method = "GET"
+                    data = None
+                continue
+            return resp.real_url, await resp.text()
+    raise CannotConnect("Too many redirects during AES Indiana login")
+
+
+class AESIndiana(UtilityBase):
+    """AES Indiana utility implementation."""
+
+    @staticmethod
+    def name() -> str:
+        """Return the name of the utility."""
+        return "AES Indiana"
+
+    @staticmethod
+    def subdomain() -> str:
+        """Return the opower.com subdomain for this utility."""
+        return "aesi"
+
+    @staticmethod
+    def timezone() -> str:
+        """Return the timezone."""
+        return "America/Indiana/Indianapolis"
+
+    @staticmethod
+    async def async_login(
+        session: aiohttp.ClientSession,
+        username: str,
+        password: str,
+        login_data: dict[str, Any],
+    ) -> None:
+        """Login via myaccount.aesindiana.com and ride the SAML SSO into opower."""
+        # Step 1: start at the opower dashboard; redirects end on the
+        # myaccount login page carrying the SAML request in ReturnURL.
+        login_page_url, login_html = await _request(session, "GET", URL("https://aesi.opower.com/ei/x/dashboard"))
+        if login_page_url.host != "myaccount.aesindiana.com":
+            raise CannotConnect(f"Unexpected login redirect target: {login_page_url}")
+
+        # Step 2: POST the ASP.NET login form with every field it served.
+        login_form = FormParser()
+        login_form.feed(login_html)
+        password_field_found = False
+        for name in list(login_form.inputs):
+            if name.endswith("$UserName"):
+                login_form.inputs[name] = username
+            elif name.endswith("$Password"):
+                login_form.inputs[name] = password
+                password_field_found = True
+        if not password_field_found:
+            raise CannotConnect("Could not find the AES Indiana login form")
+
+        url, html = await _request(session, "POST", login_page_url, login_form.inputs)
+
+        # Step 3/4: follow auto-submit forms (SAMLResponse to IDCS
+        # /fed/v1/sp/sso, etc.) until we land back on opower with a session.
+        for _ in range(4):
+            if url.host is not None and url.host.endswith("opower.com"):
+                return
+            form = FormParser()
+            form.feed(html)
+            if not form.action or not ("SAMLResponse" in form.inputs or "OCIS_REQ_SP" in form.inputs):
+                # Still on myaccount with a password field => bad credentials.
+                if any(name.endswith("$Password") for name in form.inputs):
+                    raise InvalidAuth("Invalid AES Indiana credentials")
+                raise CannotConnect("Unexpected page during AES Indiana SSO")
+            action = url.join(URL(form.action, encoded=True))
+            _LOGGER.debug("Auto-submitting SSO form to %s", action)
+            url, html = await _request(session, "POST", action, form.inputs)
+
+        raise CannotConnect("AES Indiana SSO did not reach opower.com")

--- a/src/opower/utilities/aesindiana.py
+++ b/src/opower/utilities/aesindiana.py
@@ -94,7 +94,11 @@ async def _request(
                 except ValueError as err:
                     raise CannotConnect("Invalid redirect target during AES Indiana login") from err
                 _LOGGER.debug("Redirect -> %s", _redact(url))
-                if resp.status not in (307, 308):
+                if resp.status in (307, 308):
+                    # 307/308 re-send the body; never forward it off the SSO hosts.
+                    if data is not None and not _is_allowed_sso_host(url):
+                        raise CannotConnect(f"Unexpected redirect target for AES Indiana POST: {_redact(url)}")
+                else:
                     method = "GET"
                     data = None
                 continue
@@ -201,6 +205,8 @@ class AESIndiana(UtilityBase):
             # Post to the form's action like a browser would (relative to the
             # page URL); an empty/missing action means the current URL.
             action = url.join(URL(login_form.action, encoded=True)) if login_form.action else url
+            if not _is_allowed_sso_host(action):
+                raise CannotConnect(f"Unexpected AES Indiana login form target: {_redact(action)}")
             url, html = await _request(session, "POST", action, login_form.inputs, auth_request=True, referer=url)
 
         # Step 3/4: follow auto-submit forms until we land back on opower.

--- a/src/opower/utilities/helpers.py
+++ b/src/opower/utilities/helpers.py
@@ -3,44 +3,80 @@
 from html.parser import HTMLParser
 
 
-class _FirstFormParser(HTMLParser):
-    """Collect the action and hidden inputs of the first form in a page.
+class Form:
+    """A parsed HTML form: its action and the fields a browser would submit."""
 
-    Inputs are only collected while that form is open, so a page containing
+    def __init__(self, action: str | None) -> None:
+        """Initialize."""
+        self.action = action
+        self.inputs: dict[str, str] = {}
+        self.hidden_inputs: dict[str, str] = {}
+        self.has_password = False
+        self._submit_seen = False
+
+    def add_input(self, attrs: dict[str, str | None]) -> None:
+        """Add an input field, applying browser form-submission rules."""
+        name = attrs.get("name")
+        input_type = (attrs.get("type") or "text").lower()
+        if input_type == "password":
+            self.has_password = True
+        if not name:
+            return
+        # Match what a browser submits: skip non-submitting controls,
+        # unchecked boxes, and all but the activated (first) submit button.
+        if input_type in ("button", "reset", "image"):
+            return
+        if input_type in ("checkbox", "radio") and "checked" not in attrs:
+            return
+        if input_type == "submit":
+            if self._submit_seen:
+                return
+            self._submit_seen = True
+        value = attrs.get("value") or ""
+        self.inputs[name] = value
+        if input_type == "hidden":
+            self.hidden_inputs[name] = value
+
+
+class FormsParser(HTMLParser):
+    """HTML parser that captures every form on the page with its input fields.
+
+    Inputs are only collected while their form is open, so a page containing
     more than one form cannot mix another form's fields into the result.
     """
 
     def __init__(self) -> None:
         """Initialize."""
         super().__init__()
-        self.action_url = ""
-        self.inputs: dict[str, str] = {}
-        self._in_form = False
-        self._seen_form = False
+        self.forms: list[Form] = []
+        self._current: Form | None = None
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
-        """Open the first form, or record a hidden input belonging to it."""
+        """Track forms and collect their inputs."""
         attrs_dict = dict(attrs)
         if tag == "form":
-            if self._seen_form:
-                return
-            self._seen_form = True
-            self._in_form = True
-            self.action_url = attrs_dict.get("action") or ""
-        elif tag == "input" and self._in_form and (attrs_dict.get("type") or "").lower() == "hidden":
-            name = attrs_dict.get("name")
-            if name:
-                self.inputs[name] = attrs_dict.get("value") or ""
+            self._current = Form(attrs_dict.get("action"))
+            self.forms.append(self._current)
+        elif tag == "input" and self._current is not None:
+            self._current.add_input(attrs_dict)
 
     def handle_endtag(self, tag: str) -> None:
-        """Close the form."""
+        """Close the current form."""
         if tag == "form":
-            self._in_form = False
+            self._current = None
+
+
+def parse_forms(html: str) -> list[Form]:
+    """Parse all forms out of an HTML page."""
+    parser = FormsParser()
+    parser.feed(html)
+    parser.close()
+    return parser.forms
 
 
 def get_form_action_url_and_hidden_inputs(html: str) -> tuple[str, dict[str, str]]:
     """Return the URL and hidden inputs from the first form in a page."""
-    parser = _FirstFormParser()
-    parser.feed(html)
-    parser.close()
-    return parser.action_url, parser.inputs
+    forms = parse_forms(html)
+    if not forms:
+        return "", {}
+    return forms[0].action or "", forms[0].hidden_inputs

--- a/tests/opower/utilities/test_aesindiana.py
+++ b/tests/opower/utilities/test_aesindiana.py
@@ -40,6 +40,13 @@ SAML_TO_UNEXPECTED_HOST_HTML = """
 </form>
 """
 
+EVIL_ACTION_LOGIN_HTML = """
+<form method="post" action="https://evil.example.com/login">
+  <input type="text" name="ctl00$iplLogin$UserName" />
+  <input type="password" name="ctl00$iplLogin$Password" />
+</form>
+"""
+
 RENAMED_FIELDS_LOGIN_HTML = """
 <form method="post" action="">
   <input type="text" name="ctl00$login$Account" />
@@ -232,6 +239,31 @@ class TestLoginFlow(unittest.IsolatedAsyncioTestCase):
         )
         with self.assertRaises(CannotConnect):
             await AESIndiana().async_login(session, "user@example.com", "hunter2", {})  # type: ignore[arg-type]
+
+    async def test_login_form_to_unexpected_host(self) -> None:
+        """A login form targeting a host outside the allow-list never receives credentials."""
+        session = FakeSession(
+            {
+                ("GET", DASHBOARD_URL): [FakeResponse(DASHBOARD_URL, 302, location=LOGIN_URL)],
+                ("GET", LOGIN_URL): [FakeResponse(LOGIN_URL, body=EVIL_ACTION_LOGIN_HTML)],
+            }
+        )
+        with self.assertRaises(CannotConnect):
+            await AESIndiana().async_login(session, "user@example.com", "hunter2", {})  # type: ignore[arg-type]
+        self.assertFalse(any(method == "POST" for method, _, _ in session.requests))
+
+    async def test_login_post_not_forwarded_offhost(self) -> None:
+        """A 307 redirect of the credential POST to an off-list host is refused."""
+        session = FakeSession(
+            {
+                ("GET", DASHBOARD_URL): [FakeResponse(DASHBOARD_URL, 302, location=LOGIN_URL)],
+                ("GET", LOGIN_URL): [FakeResponse(LOGIN_URL, body=LOGIN_PAGE_HTML)],
+                ("POST", LOGIN_POST_URL): [FakeResponse(LOGIN_POST_URL, 307, location="https://evil.example.com/sink")],
+            }
+        )
+        with self.assertRaises(CannotConnect):
+            await AESIndiana().async_login(session, "user@example.com", "hunter2", {})  # type: ignore[arg-type]
+        self.assertFalse(any("evil.example.com" in url for _, url, _ in session.requests))
 
     async def test_sso_form_to_unexpected_host(self) -> None:
         """An SSO form targeting a host outside the allow-list is not posted."""

--- a/tests/opower/utilities/test_aesindiana.py
+++ b/tests/opower/utilities/test_aesindiana.py
@@ -1,40 +1,116 @@
 """Tests for AES Indiana."""
 
 import unittest
+from typing import Any
 
-from opower.utilities.aesindiana import AESIndiana, _parse_forms
+import aiohttp
+from yarl import URL
+
+from opower.exceptions import CannotConnect, InvalidAuth
+from opower.utilities.aesindiana import AESIndiana, _complete_sso, _is_allowed_sso_host
+
+DASHBOARD_URL = "https://aesi.opower.com/ei/x/dashboard"
+CUSTOMERS_URL = "https://aesi.opower.com/ei/edge/apis/multi-account-v1/cws/aesi/customers"
+LOGIN_URL = "https://myaccount.aesindiana.com/SAML/ssoservice.aspx?SAMLRequest=abc"
+# Where the login form's relative action ("./?ReturnURL=...") resolves to.
+LOGIN_POST_URL = "https://myaccount.aesindiana.com/SAML/?ReturnURL=%2fSAML%2fssoservice.aspx"
+IDCS_SSO_URL = "https://idcs-abc.identity.oraclecloud.com/fed/v1/sp/sso"
 
 LOGIN_PAGE_HTML = """
-<form method="get" action="/search" id="siteSearch">
-  <input type="text" name="q" />
-  <input type="submit" name="searchButton" value="Search" />
-</form>
 <form method="post" action="./?ReturnURL=%2fSAML%2fssoservice.aspx" id="Form1">
   <input type="hidden" name="__VIEWSTATE" value="viewstate123" />
-  <input type="hidden" name="__VIEWSTATEGENERATOR" value="ABCD1234" />
-  <input type="hidden" name="__EVENTVALIDATION" value="ev456" />
   <input type="text" name="ctl00$phMainColumn$ctl00$iplLogin$UserName" />
   <input type="password" name="ctl00$phMainColumn$ctl00$iplLogin$Password" />
-  <input type="checkbox" name="ctl00$phMainColumn$ctl00$iplLogin$cbRemember" />
   <input type="submit" name="ctl00$phMainColumn$ctl00$iplLogin$LoginButton" value="Log In" />
-  <input type="submit" name="ctl00$phMainColumn$ctl00$iplLogin$ForgotButton" value="Forgot?" />
 </form>
 """
 
-SAML_AUTOSUBMIT_HTML = """
+SAML_AUTOSUBMIT_HTML = f"""
 <html><body onload="document.forms[0].submit()">
-<form method="post" action="https://idcs-abc.identity.oraclecloud.com/fed/v1/sp/sso">
+<form method="post" action="{IDCS_SSO_URL}">
   <input type="hidden" name="SAMLResponse" value="c2FtbA==" />
   <input type="hidden" name="RelayState" value="xyz" />
 </form>
 </body></html>
 """
 
-SELF_POST_HTML = """
-<form method="post" action="">
-  <input type="hidden" name="__VIEWSTATE" value="vs" />
+SAML_TO_UNEXPECTED_HOST_HTML = """
+<form method="post" action="https://evil.example.com/sso">
+  <input type="hidden" name="SAMLResponse" value="c2FtbA==" />
 </form>
 """
+
+RENAMED_FIELDS_LOGIN_HTML = """
+<form method="post" action="">
+  <input type="text" name="ctl00$login$Account" />
+  <input type="password" name="ctl00$login$Secret" />
+</form>
+"""
+
+
+class FakeResponse:
+    """A canned aiohttp-like response usable as an async context manager."""
+
+    def __init__(self, url: str, status: int = 200, body: str = "", location: str | None = None) -> None:
+        """Initialize."""
+        self.real_url = URL(url)
+        self.status = status
+        self._body = body
+        self.headers = {"Location": location} if location else {}
+        self.raise_on_enter = False
+
+    async def text(self) -> str:
+        """Return the canned body."""
+        return self._body
+
+    def raise_for_status(self) -> None:
+        """Raise like aiohttp for error statuses."""
+        if self.status >= 400:
+            raise aiohttp.ClientResponseError(request_info=None, history=(), status=self.status)  # type: ignore[arg-type]
+
+    async def __aenter__(self) -> "FakeResponse":
+        """Enter, raising for status if requested at the session level."""
+        if self.raise_on_enter:
+            self.raise_for_status()
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        """Exit."""
+
+
+class FakeCookieJar:
+    """Cookie jar stub that records clears."""
+
+    def __init__(self) -> None:
+        """Initialize."""
+        self.cleared = False
+
+    def clear(self, predicate: Any = None) -> None:
+        """Record that cookies were cleared."""
+        self.cleared = True
+
+
+class FakeSession:
+    """aiohttp.ClientSession stub serving scripted responses per (method, url)."""
+
+    def __init__(self, responses: dict[tuple[str, str], list[FakeResponse]]) -> None:
+        """Initialize."""
+        self._responses = responses
+        self.requests: list[tuple[str, str, dict[str, str] | None]] = []
+        self.cookie_jar = FakeCookieJar()
+
+    def request(self, method: str, url: Any, data: Any = None, raise_for_status: bool = False, **kwargs: Any) -> FakeResponse:
+        """Serve the next scripted response for this method and URL."""
+        self.requests.append((method, str(url), data))
+        responses = self._responses.get((method, str(url)))
+        assert responses, f"Unexpected request: {method} {url}"
+        response = responses.pop(0)
+        response.raise_on_enter = raise_for_status
+        return response
+
+    def get(self, url: Any, **kwargs: Any) -> FakeResponse:
+        """Serve a GET request."""
+        return self.request("GET", url, **kwargs)
 
 
 class TestAESIndiana(unittest.TestCase):
@@ -46,55 +122,137 @@ class TestAESIndiana(unittest.TestCase):
 
     def test_subdomain(self) -> None:
         """Test subdomain."""
-        self.assertEqual("aesi", AESIndiana.subdomain())
+        self.assertEqual("aesi", AESIndiana().subdomain())
 
     def test_timezone(self) -> None:
         """Test timezone."""
         self.assertEqual("America/Indiana/Indianapolis", AESIndiana.timezone())
 
 
-class TestFormsParser(unittest.TestCase):
-    """Test the login/SSO form parsing."""
+class TestAllowedSSOHosts(unittest.TestCase):
+    """Test the allow-list guarding where SAML assertions may be posted."""
 
-    def test_login_form_selected_by_password_field(self) -> None:
-        """The login form is found by its password input, not document order."""
-        forms = _parse_forms(LOGIN_PAGE_HTML)
-        self.assertEqual(2, len(forms))
-        login = next(f for f in forms if f.has_password)
-        self.assertEqual("./?ReturnURL=%2fSAML%2fssoservice.aspx", login.action)
-        self.assertIn("__VIEWSTATE", login.inputs)
-        self.assertIn("__EVENTVALIDATION", login.inputs)
-        self.assertIn("ctl00$phMainColumn$ctl00$iplLogin$UserName", login.inputs)
-        self.assertIn("ctl00$phMainColumn$ctl00$iplLogin$Password", login.inputs)
+    def test_allowed_hosts(self) -> None:
+        """The three legitimate hosts of the SSO chain are allowed."""
+        self.assertTrue(_is_allowed_sso_host(URL("https://myaccount.aesindiana.com/SAML/ssoservice.aspx")))
+        self.assertTrue(_is_allowed_sso_host(URL(IDCS_SSO_URL)))
+        self.assertTrue(_is_allowed_sso_host(URL(DASHBOARD_URL)))
 
-    def test_browser_submission_rules(self) -> None:
-        """Unchecked checkboxes and extra submit buttons are not submitted."""
-        login = next(f for f in _parse_forms(LOGIN_PAGE_HTML) if f.has_password)
-        self.assertNotIn("ctl00$phMainColumn$ctl00$iplLogin$cbRemember", login.inputs)
-        self.assertIn("ctl00$phMainColumn$ctl00$iplLogin$LoginButton", login.inputs)
-        self.assertNotIn("ctl00$phMainColumn$ctl00$iplLogin$ForgotButton", login.inputs)
+    def test_disallowed_hosts(self) -> None:
+        """Lookalike and unrelated hosts are rejected."""
+        self.assertFalse(_is_allowed_sso_host(URL("https://evil.example.com/sso")))
+        self.assertFalse(_is_allowed_sso_host(URL("https://identity.oraclecloud.com/sso")))
+        self.assertFalse(_is_allowed_sso_host(URL("https://aesi.opower.com.evil.com/sso")))
+        self.assertFalse(_is_allowed_sso_host(URL("https://notmyaccount.aesindiana.com/sso")))
 
-    def test_forms_are_isolated(self) -> None:
-        """Inputs from one form do not leak into another."""
-        forms = _parse_forms(LOGIN_PAGE_HTML)
-        search = next(f for f in forms if not f.has_password)
-        self.assertEqual("/search", search.action)
-        self.assertNotIn("__VIEWSTATE", search.inputs)
-        login = next(f for f in forms if f.has_password)
-        self.assertNotIn("q", login.inputs)
+    def test_non_https_disallowed(self) -> None:
+        """Plain-http targets are rejected even on otherwise allowed hosts."""
+        self.assertFalse(_is_allowed_sso_host(URL("http://myaccount.aesindiana.com/SAML/ssoservice.aspx")))
+        self.assertFalse(_is_allowed_sso_host(URL("http://idcs-abc.identity.oraclecloud.com/fed/v1/sp/sso")))
 
-    def test_saml_autosubmit_form(self) -> None:
-        """The SAML auto-submit form is detected with its assertion payload."""
-        forms = _parse_forms(SAML_AUTOSUBMIT_HTML)
-        self.assertEqual(1, len(forms))
-        self.assertEqual("https://idcs-abc.identity.oraclecloud.com/fed/v1/sp/sso", forms[0].action)
-        self.assertEqual("c2FtbA==", forms[0].inputs["SAMLResponse"])
-        self.assertEqual("xyz", forms[0].inputs["RelayState"])
-        self.assertFalse(forms[0].has_password)
 
-    def test_empty_action_self_post_form(self) -> None:
-        """A form with an empty action parses with its fields intact."""
-        forms = _parse_forms(SELF_POST_HTML)
-        self.assertEqual(1, len(forms))
-        self.assertEqual("", forms[0].action)
-        self.assertEqual({"__VIEWSTATE": "vs"}, forms[0].inputs)
+class TestLoginFlow(unittest.IsolatedAsyncioTestCase):
+    """Test async_login and _complete_sso against a fake session with canned pages."""
+
+    async def test_full_login(self) -> None:
+        """A fresh login walks the whole chain: login form, SAML post, back to opower."""
+        session = FakeSession(
+            {
+                ("GET", DASHBOARD_URL): [
+                    FakeResponse(DASHBOARD_URL, 302, location=LOGIN_URL),
+                    # Requested again by the redirect after the SAML post.
+                    FakeResponse(DASHBOARD_URL, body="<html>usage</html>"),
+                ],
+                ("GET", LOGIN_URL): [FakeResponse(LOGIN_URL, body=LOGIN_PAGE_HTML)],
+                ("POST", LOGIN_POST_URL): [FakeResponse(LOGIN_URL, body=SAML_AUTOSUBMIT_HTML)],
+                ("POST", IDCS_SSO_URL): [FakeResponse(IDCS_SSO_URL, 302, location=DASHBOARD_URL)],
+            }
+        )
+
+        await AESIndiana().async_login(session, "user@example.com", "hunter2", {})  # type: ignore[arg-type]
+
+        login_post = next(data for method, url, data in session.requests if method == "POST" and url == LOGIN_POST_URL)
+        assert login_post is not None
+        self.assertEqual("user@example.com", login_post["ctl00$phMainColumn$ctl00$iplLogin$UserName"])
+        self.assertEqual("hunter2", login_post["ctl00$phMainColumn$ctl00$iplLogin$Password"])
+        self.assertEqual("viewstate123", login_post["__VIEWSTATE"])
+        saml_post = next(data for method, url, data in session.requests if method == "POST" and url == IDCS_SSO_URL)
+        assert saml_post is not None
+        self.assertEqual("c2FtbA==", saml_post["SAMLResponse"])
+
+    async def test_valid_existing_session_skips_sso(self) -> None:
+        """A still-valid opower session is verified with an API call and reused."""
+        session = FakeSession(
+            {
+                ("GET", DASHBOARD_URL): [FakeResponse(DASHBOARD_URL, body="<html>usage</html>")],
+                ("GET", CUSTOMERS_URL): [FakeResponse(CUSTOMERS_URL, body="{}")],
+            }
+        )
+        await AESIndiana().async_login(session, "user@example.com", "hunter2", {})  # type: ignore[arg-type]
+        self.assertEqual(2, len(session.requests))
+        self.assertFalse(session.cookie_jar.cleared)
+
+    async def test_stale_session_clears_cookies_and_relogs(self) -> None:
+        """A stale opower session fails the API check, clears cookies, and logs in again."""
+        session = FakeSession(
+            {
+                ("GET", DASHBOARD_URL): [
+                    FakeResponse(DASHBOARD_URL, body="<html>stale</html>"),
+                    FakeResponse(DASHBOARD_URL, 302, location=LOGIN_URL),
+                    FakeResponse(DASHBOARD_URL, body="<html>usage</html>"),
+                ],
+                ("GET", CUSTOMERS_URL): [FakeResponse(CUSTOMERS_URL, 401)],
+                ("GET", LOGIN_URL): [FakeResponse(LOGIN_URL, body=LOGIN_PAGE_HTML)],
+                ("POST", LOGIN_POST_URL): [FakeResponse(LOGIN_URL, body=SAML_AUTOSUBMIT_HTML)],
+                ("POST", IDCS_SSO_URL): [FakeResponse(IDCS_SSO_URL, 302, location=DASHBOARD_URL)],
+            }
+        )
+        await AESIndiana().async_login(session, "user@example.com", "hunter2", {})  # type: ignore[arg-type]
+        self.assertTrue(session.cookie_jar.cleared)
+
+    async def test_invalid_credentials(self) -> None:
+        """Re-serving the login page after the credential post raises InvalidAuth."""
+        session = FakeSession(
+            {
+                ("GET", DASHBOARD_URL): [FakeResponse(DASHBOARD_URL, 302, location=LOGIN_URL)],
+                ("GET", LOGIN_URL): [FakeResponse(LOGIN_URL, body=LOGIN_PAGE_HTML)],
+                ("POST", LOGIN_POST_URL): [FakeResponse(LOGIN_URL, body=LOGIN_PAGE_HTML)],
+            }
+        )
+        with self.assertRaises(InvalidAuth):
+            await AESIndiana().async_login(session, "user@example.com", "wrong", {})  # type: ignore[arg-type]
+
+    async def test_renamed_credential_fields(self) -> None:
+        """Unrecognized credential field names fail fast instead of posting empty values."""
+        session = FakeSession(
+            {
+                ("GET", DASHBOARD_URL): [FakeResponse(DASHBOARD_URL, 302, location=LOGIN_URL)],
+                ("GET", LOGIN_URL): [FakeResponse(LOGIN_URL, body=RENAMED_FIELDS_LOGIN_HTML)],
+            }
+        )
+        with self.assertRaises(CannotConnect):
+            await AESIndiana().async_login(session, "user@example.com", "hunter2", {})  # type: ignore[arg-type]
+
+    async def test_sso_form_to_unexpected_host(self) -> None:
+        """An SSO form targeting a host outside the allow-list is not posted."""
+        session = FakeSession({})
+        with self.assertRaises(CannotConnect):
+            await _complete_sso(session, URL(LOGIN_URL), SAML_TO_UNEXPECTED_HOST_HTML)  # type: ignore[arg-type]
+        self.assertEqual(0, len(session.requests))
+
+    async def test_sso_unexpected_page(self) -> None:
+        """A page with neither an SSO form nor a login form raises CannotConnect."""
+        session = FakeSession({})
+        with self.assertRaises(CannotConnect):
+            await _complete_sso(session, URL(LOGIN_URL), "<html><body>maintenance</body></html>")  # type: ignore[arg-type]
+
+    async def test_sso_never_reaches_opower(self) -> None:
+        """An SSO loop that never lands on opower gives up with CannotConnect."""
+        looping_html = f"""
+        <form method="post" action="{IDCS_SSO_URL}">
+          <input type="hidden" name="SAMLResponse" value="c2FtbA==" />
+        </form>
+        """
+        session = FakeSession({("POST", IDCS_SSO_URL): [FakeResponse(IDCS_SSO_URL, body=looping_html) for _ in range(5)]})
+        with self.assertRaises(CannotConnect):
+            await _complete_sso(session, URL(LOGIN_URL), looping_html)  # type: ignore[arg-type]

--- a/tests/opower/utilities/test_aesindiana.py
+++ b/tests/opower/utilities/test_aesindiana.py
@@ -1,0 +1,100 @@
+"""Tests for AES Indiana."""
+
+import unittest
+
+from opower.utilities.aesindiana import AESIndiana, _parse_forms
+
+LOGIN_PAGE_HTML = """
+<form method="get" action="/search" id="siteSearch">
+  <input type="text" name="q" />
+  <input type="submit" name="searchButton" value="Search" />
+</form>
+<form method="post" action="./?ReturnURL=%2fSAML%2fssoservice.aspx" id="Form1">
+  <input type="hidden" name="__VIEWSTATE" value="viewstate123" />
+  <input type="hidden" name="__VIEWSTATEGENERATOR" value="ABCD1234" />
+  <input type="hidden" name="__EVENTVALIDATION" value="ev456" />
+  <input type="text" name="ctl00$phMainColumn$ctl00$iplLogin$UserName" />
+  <input type="password" name="ctl00$phMainColumn$ctl00$iplLogin$Password" />
+  <input type="checkbox" name="ctl00$phMainColumn$ctl00$iplLogin$cbRemember" />
+  <input type="submit" name="ctl00$phMainColumn$ctl00$iplLogin$LoginButton" value="Log In" />
+  <input type="submit" name="ctl00$phMainColumn$ctl00$iplLogin$ForgotButton" value="Forgot?" />
+</form>
+"""
+
+SAML_AUTOSUBMIT_HTML = """
+<html><body onload="document.forms[0].submit()">
+<form method="post" action="https://idcs-abc.identity.oraclecloud.com/fed/v1/sp/sso">
+  <input type="hidden" name="SAMLResponse" value="c2FtbA==" />
+  <input type="hidden" name="RelayState" value="xyz" />
+</form>
+</body></html>
+"""
+
+SELF_POST_HTML = """
+<form method="post" action="">
+  <input type="hidden" name="__VIEWSTATE" value="vs" />
+</form>
+"""
+
+
+class TestAESIndiana(unittest.TestCase):
+    """Test public methods inherited from UtilityBase."""
+
+    def test_name(self) -> None:
+        """Test name."""
+        self.assertEqual("AES Indiana", AESIndiana.name())
+
+    def test_subdomain(self) -> None:
+        """Test subdomain."""
+        self.assertEqual("aesi", AESIndiana.subdomain())
+
+    def test_timezone(self) -> None:
+        """Test timezone."""
+        self.assertEqual("America/Indiana/Indianapolis", AESIndiana.timezone())
+
+
+class TestFormsParser(unittest.TestCase):
+    """Test the login/SSO form parsing."""
+
+    def test_login_form_selected_by_password_field(self) -> None:
+        """The login form is found by its password input, not document order."""
+        forms = _parse_forms(LOGIN_PAGE_HTML)
+        self.assertEqual(2, len(forms))
+        login = next(f for f in forms if f.has_password)
+        self.assertEqual("./?ReturnURL=%2fSAML%2fssoservice.aspx", login.action)
+        self.assertIn("__VIEWSTATE", login.inputs)
+        self.assertIn("__EVENTVALIDATION", login.inputs)
+        self.assertIn("ctl00$phMainColumn$ctl00$iplLogin$UserName", login.inputs)
+        self.assertIn("ctl00$phMainColumn$ctl00$iplLogin$Password", login.inputs)
+
+    def test_browser_submission_rules(self) -> None:
+        """Unchecked checkboxes and extra submit buttons are not submitted."""
+        login = next(f for f in _parse_forms(LOGIN_PAGE_HTML) if f.has_password)
+        self.assertNotIn("ctl00$phMainColumn$ctl00$iplLogin$cbRemember", login.inputs)
+        self.assertIn("ctl00$phMainColumn$ctl00$iplLogin$LoginButton", login.inputs)
+        self.assertNotIn("ctl00$phMainColumn$ctl00$iplLogin$ForgotButton", login.inputs)
+
+    def test_forms_are_isolated(self) -> None:
+        """Inputs from one form do not leak into another."""
+        forms = _parse_forms(LOGIN_PAGE_HTML)
+        search = next(f for f in forms if not f.has_password)
+        self.assertEqual("/search", search.action)
+        self.assertNotIn("__VIEWSTATE", search.inputs)
+        login = next(f for f in forms if f.has_password)
+        self.assertNotIn("q", login.inputs)
+
+    def test_saml_autosubmit_form(self) -> None:
+        """The SAML auto-submit form is detected with its assertion payload."""
+        forms = _parse_forms(SAML_AUTOSUBMIT_HTML)
+        self.assertEqual(1, len(forms))
+        self.assertEqual("https://idcs-abc.identity.oraclecloud.com/fed/v1/sp/sso", forms[0].action)
+        self.assertEqual("c2FtbA==", forms[0].inputs["SAMLResponse"])
+        self.assertEqual("xyz", forms[0].inputs["RelayState"])
+        self.assertFalse(forms[0].has_password)
+
+    def test_empty_action_self_post_form(self) -> None:
+        """A form with an empty action parses with its fields intact."""
+        forms = _parse_forms(SELF_POST_HTML)
+        self.assertEqual(1, len(forms))
+        self.assertEqual("", forms[0].action)
+        self.assertEqual({"__VIEWSTATE": "vs"}, forms[0].inputs)

--- a/tests/opower/utilities/test_helpers.py
+++ b/tests/opower/utilities/test_helpers.py
@@ -101,6 +101,12 @@ class TestGetFormActionUrlAndHiddenInputs(unittest.TestCase):
         self.assertEqual("https://idcs-abc.identity.oraclecloud.com/fed/v1/sp/sso", action)
         self.assertEqual({"SAMLResponse": "c2FtbA==", "RelayState": "xyz"}, inputs)
 
+    def test_first_form_only(self) -> None:
+        """Only the first form is used; later forms' fields cannot leak in."""
+        action, inputs = get_form_action_url_and_hidden_inputs(LOGIN_PAGE_HTML)
+        self.assertEqual("/search", action)
+        self.assertEqual({}, inputs)
+
     def test_no_form(self) -> None:
         """A page without forms returns empty values."""
         action, inputs = get_form_action_url_and_hidden_inputs("<html><body>hi</body></html>")

--- a/tests/opower/utilities/test_helpers.py
+++ b/tests/opower/utilities/test_helpers.py
@@ -1,0 +1,108 @@
+"""Tests for the shared form-parsing helpers."""
+
+import unittest
+
+from opower.utilities.helpers import get_form_action_url_and_hidden_inputs, parse_forms
+
+LOGIN_PAGE_HTML = """
+<form method="get" action="/search" id="siteSearch">
+  <input type="text" name="q" />
+  <input type="submit" name="searchButton" value="Search" />
+</form>
+<form method="post" action="./?ReturnURL=%2fSAML%2fssoservice.aspx" id="Form1">
+  <input type="hidden" name="__VIEWSTATE" value="viewstate123" />
+  <input type="hidden" name="__VIEWSTATEGENERATOR" value="ABCD1234" />
+  <input type="hidden" name="__EVENTVALIDATION" value="ev456" />
+  <input type="text" name="ctl00$phMainColumn$ctl00$iplLogin$UserName" />
+  <input type="password" name="ctl00$phMainColumn$ctl00$iplLogin$Password" />
+  <input type="checkbox" name="ctl00$phMainColumn$ctl00$iplLogin$cbRemember" />
+  <input type="submit" name="ctl00$phMainColumn$ctl00$iplLogin$LoginButton" value="Log In" />
+  <input type="submit" name="ctl00$phMainColumn$ctl00$iplLogin$ForgotButton" value="Forgot?" />
+</form>
+"""
+
+SAML_AUTOSUBMIT_HTML = """
+<html><body onload="document.forms[0].submit()">
+<form method="post" action="https://idcs-abc.identity.oraclecloud.com/fed/v1/sp/sso">
+  <input type="hidden" name="SAMLResponse" value="c2FtbA==" />
+  <input type="hidden" name="RelayState" value="xyz" />
+</form>
+</body></html>
+"""
+
+SELF_POST_HTML = """
+<form method="post" action="">
+  <input type="hidden" name="__VIEWSTATE" value="vs" />
+</form>
+"""
+
+
+class TestFormsParser(unittest.TestCase):
+    """Test the multi-form HTML parsing."""
+
+    def test_login_form_selected_by_password_field(self) -> None:
+        """The login form is found by its password input, not document order."""
+        forms = parse_forms(LOGIN_PAGE_HTML)
+        self.assertEqual(2, len(forms))
+        login = next(f for f in forms if f.has_password)
+        self.assertEqual("./?ReturnURL=%2fSAML%2fssoservice.aspx", login.action)
+        self.assertIn("__VIEWSTATE", login.inputs)
+        self.assertIn("__EVENTVALIDATION", login.inputs)
+        self.assertIn("ctl00$phMainColumn$ctl00$iplLogin$UserName", login.inputs)
+        self.assertIn("ctl00$phMainColumn$ctl00$iplLogin$Password", login.inputs)
+
+    def test_browser_submission_rules(self) -> None:
+        """Unchecked checkboxes and extra submit buttons are not submitted."""
+        login = next(f for f in parse_forms(LOGIN_PAGE_HTML) if f.has_password)
+        self.assertNotIn("ctl00$phMainColumn$ctl00$iplLogin$cbRemember", login.inputs)
+        self.assertIn("ctl00$phMainColumn$ctl00$iplLogin$LoginButton", login.inputs)
+        self.assertNotIn("ctl00$phMainColumn$ctl00$iplLogin$ForgotButton", login.inputs)
+
+    def test_forms_are_isolated(self) -> None:
+        """Inputs from one form do not leak into another."""
+        forms = parse_forms(LOGIN_PAGE_HTML)
+        search = next(f for f in forms if not f.has_password)
+        self.assertEqual("/search", search.action)
+        self.assertNotIn("__VIEWSTATE", search.inputs)
+        login = next(f for f in forms if f.has_password)
+        self.assertNotIn("q", login.inputs)
+
+    def test_saml_autosubmit_form(self) -> None:
+        """The SAML auto-submit form is detected with its assertion payload."""
+        forms = parse_forms(SAML_AUTOSUBMIT_HTML)
+        self.assertEqual(1, len(forms))
+        self.assertEqual("https://idcs-abc.identity.oraclecloud.com/fed/v1/sp/sso", forms[0].action)
+        self.assertEqual("c2FtbA==", forms[0].inputs["SAMLResponse"])
+        self.assertEqual("xyz", forms[0].inputs["RelayState"])
+        self.assertFalse(forms[0].has_password)
+
+    def test_empty_action_self_post_form(self) -> None:
+        """A form with an empty action parses with its fields intact."""
+        forms = parse_forms(SELF_POST_HTML)
+        self.assertEqual(1, len(forms))
+        self.assertEqual("", forms[0].action)
+        self.assertEqual({"__VIEWSTATE": "vs"}, forms[0].inputs)
+
+    def test_hidden_inputs_tracked_separately(self) -> None:
+        """Hidden inputs are available on their own, excluding visible fields."""
+        login = next(f for f in parse_forms(LOGIN_PAGE_HTML) if f.has_password)
+        self.assertEqual(
+            {"__VIEWSTATE", "__VIEWSTATEGENERATOR", "__EVENTVALIDATION"},
+            set(login.hidden_inputs),
+        )
+
+
+class TestGetFormActionUrlAndHiddenInputs(unittest.TestCase):
+    """Test the single-form convenience wrapper."""
+
+    def test_single_form(self) -> None:
+        """The action and hidden inputs of the form are returned."""
+        action, inputs = get_form_action_url_and_hidden_inputs(SAML_AUTOSUBMIT_HTML)
+        self.assertEqual("https://idcs-abc.identity.oraclecloud.com/fed/v1/sp/sso", action)
+        self.assertEqual({"SAMLResponse": "c2FtbA==", "RelayState": "xyz"}, inputs)
+
+    def test_no_form(self) -> None:
+        """A page without forms returns empty values."""
+        action, inputs = get_form_action_url_and_hidden_inputs("<html><body>hi</body></html>")
+        self.assertEqual("", action)
+        self.assertEqual({}, inputs)


### PR DESCRIPTION
## Summary

Adds support for **AES Indiana** (formerly Indianapolis Power & Light), the electric utility for Indianapolis, IN. Their usage portal ("PowerView") runs on Opower at `aesi.opower.com`. Requested in home-assistant discussion [#3256](https://github.com/orgs/home-assistant/discussions/3256).

## Login flow

AES Indiana's native Opower signin endpoint exists but does not accept portal credentials -- accounts are SSO-only via the customer portal. The module therefore logs in the way a browser does:

1. `GET https://aesi.opower.com/ei/x/dashboard` -> redirects through `/ei/app/api/authenticate` -> Oracle IDCS (`/oauth2/v1/authorize`, client `Opower_SSO_aesi_prod_APPID`) -> a signed SAML request to `myaccount.aesindiana.com/SAML/ssoservice.aspx` -> the ASP.NET login page
2. POST the login form, scraping **all** served fields at once (per the HA web-scraping ADR's auth-phase exception)
3. Follow the auto-submit SAML/OCIS forms back through IDCS `/fed/v1/sp/sso` until landing on `aesi.opower.com` with session cookies (same shape as the existing SMUD implementation)

**Implementation note:** redirects are followed manually with `yarl.URL(location, encoded=True)`. aiohttp's default redirect handling re-quotes the URL, which alters the signed `SAMLRequest` query string and the IdP rejects it with *"The authn request signature failed to verify."*

## Testing

- I am an AES Indiana customer; `python -m opower --utility aesindiana` logs in and returns usage and cost data with my real credentials
- `pytest` passes (including the live `test_invalid_auth[AESIndiana]`, which exercises the full SSO chain with bogus credentials and gets the correct `InvalidAuth`)
- `pre-commit run` clean on the changed files
- Running in my Home Assistant 2026.8.2 as a custom-component override for several days: sensors populate and Energy dashboard statistics backfill correctly
