### PR TITLE
Add AES Indiana (aesi.opower.com) support

### DIFF
--- a/src/opower/utilities/aesindiana.py
+++ b/src/opower/utilities/aesindiana.py
@@ -1,0 +1,156 @@
+"""AES Indiana (formerly Indianapolis Power & Light).
+
+AES Indiana's OPower portal (aesi.opower.com) delegates authentication to
+Oracle Identity Cloud Service (IDCS) which federates to
+myaccount.aesindiana.com via SAML. The login flow is:
+
+1. GET aesi.opower.com/ei/ which redirects through OPower -> Oracle IDCS ->
+   myaccount.aesindiana.com, ending on an ASP.NET login form.
+2. POST the ASP.NET form (ViewState/EventValidation + credentials).
+3. Follow redirects back through the SAML endpoint which returns an
+   auto-submitting form containing the SAMLResponse.
+4. POST the SAMLResponse to Oracle IDCS, follow the resulting redirects
+   back to OPower which sets session cookies.
+
+All redirects must be followed manually with the raw Location header because
+aiohttp re-encodes redirect URLs by default (requote_redirect_url=True) and
+yarl's normalization breaks the byte-exact signed SAMLRequest query string,
+causing "The authn request signature failed to verify" errors.
+"""
+
+import logging
+import re
+from html import unescape
+from typing import Any
+from urllib.parse import urljoin
+
+import aiohttp
+from yarl import URL
+
+from ..const import USER_AGENT
+from ..exceptions import InvalidAuth
+from .base import UtilityBase
+
+_LOGGER = logging.getLogger(__name__)
+
+# Safety bound for the SSO flow. A full login takes ~20 requests.
+_MAX_STEPS = 40
+
+# Marker of the ASP.NET login form on myaccount.aesindiana.com.
+_LOGIN_FORM_MARKER = "iplLogin$UserName"
+_USERNAME_FIELD = "ctl00$phMainColumn$ctl00$iplLogin$UserName"
+_PASSWORD_FIELD = "ctl00$phMainColumn$ctl00$iplLogin$Password"  # noqa: S105
+_LOGIN_BUTTON_FIELD = "ctl00$phMainColumn$ctl00$iplLogin$LoginButton"
+
+_TAG_RE = re.compile(r"<(?:input|form)\b[^>]*>", re.IGNORECASE)
+_ATTR_RE = re.compile(r'([\w-]+)\s*=\s*"([^"]*)"')
+
+
+def _get_form_action_and_hidden_inputs(html: str) -> tuple[str, dict[str, str]]:
+    """Return the action URL and hidden inputs of the first form in the page.
+
+    Unlike helpers.get_form_action_url_and_hidden_inputs, this tolerates extra
+    attributes between name and value (ASP.NET renders id attributes) and
+    unescapes HTML entities: AES Indiana emits the form action with &amp;
+    separators and browsers submit decoded attribute values.
+    """
+    action_url = ""
+    inputs: dict[str, str] = {}
+    for match in _TAG_RE.finditer(html):
+        tag = match.group(0)
+        attrs = {m.group(1).lower(): unescape(m.group(2)) for m in _ATTR_RE.finditer(tag)}
+        if tag[1:5].lower() == "form":
+            if not action_url:
+                action_url = attrs.get("action", "")
+        elif attrs.get("type") == "hidden" and "name" in attrs:
+            inputs[attrs["name"]] = attrs.get("value", "")
+    return action_url, inputs
+
+
+class AESIndiana(UtilityBase):
+    """AES Indiana utility implementation."""
+
+    @staticmethod
+    def name() -> str:
+        """Return the name of the utility."""
+        return "AES Indiana"
+
+    @staticmethod
+    def subdomain() -> str:
+        """Return the opower.com subdomain for this utility."""
+        return "aesi"
+
+    @staticmethod
+    def timezone() -> str:
+        """Return the timezone."""
+        return "America/Indiana/Indianapolis"
+
+    @staticmethod
+    async def async_login(
+        session: aiohttp.ClientSession,
+        username: str,
+        password: str,
+        login_data: dict[str, Any],
+    ) -> str:
+        """Login to the AES Indiana OPower portal.
+
+        Drives the SAML SSO flow described in the module docstring and returns
+        an empty token since subsequent API calls are authorized by the
+        session cookies OPower sets (like NIPSCO).
+        """
+        # Pending request: method, URL, optional form data.
+        pending: tuple[str, str, dict[str, str] | None] = ("GET", "https://aesi.opower.com/ei/", None)
+        submitted_login = False
+
+        for step in range(_MAX_STEPS):
+            method, url, data = pending
+            _LOGGER.debug("AES Indiana login step %d: %s %s", step, method, url[:120])
+            async with session.request(
+                method,
+                # encoded=True keeps yarl from normalizing (and thus breaking)
+                # the signed SAMLRequest query string.
+                URL(url, encoded=True),
+                data=data,
+                allow_redirects=False,
+                headers={"User-Agent": USER_AGENT},
+                raise_for_status=True,
+            ) as resp:
+                status = resp.status
+                location = resp.headers.get("Location")
+                body = await resp.text()
+
+            if status in (301, 302, 303, 307, 308) and location:
+                # urljoin is a pure string operation that, unlike yarl,
+                # preserves the redirect URL bytes exactly.
+                pending = ("GET", urljoin(url, location), None)
+                continue
+
+            if _LOGIN_FORM_MARKER in body:
+                if submitted_login:
+                    # The login form is rendered again on failed logins.
+                    raise InvalidAuth("Invalid AES Indiana credentials")
+                action_url, inputs = _get_form_action_and_hidden_inputs(body)
+                inputs[_USERNAME_FIELD] = username
+                inputs[_PASSWORD_FIELD] = password
+                inputs[_LOGIN_BUTTON_FIELD] = "Sign In"
+                pending = ("POST", urljoin(url, action_url), inputs)
+                submitted_login = True
+                continue
+
+            if "SAMLResponse" in body or "OCIS_REQ" in body:
+                # Auto-submitting form that carries the SAML assertion back to
+                # Oracle IDCS.
+                action_url, inputs = _get_form_action_and_hidden_inputs(body)
+                if not action_url:
+                    raise InvalidAuth("AES Indiana login: SAML form has no action URL")
+                pending = ("POST", urljoin(url, action_url), inputs)
+                continue
+
+            if url.startswith("https://aesi.opower.com/"):
+                # Landed on the OPower dashboard; session cookies are set.
+                _LOGGER.debug("AES Indiana login successful")
+                return ""
+
+            raise InvalidAuth(f"AES Indiana login: unexpected page at {url[:120]}")
+
+        raise InvalidAuth("AES Indiana login did not complete")

--- a/src/opower/utilities/aesindiana.py
+++ b/src/opower/utilities/aesindiana.py
@@ -104,7 +104,9 @@ class AESIndiana(UtilityBase):
 
         for step in range(_MAX_STEPS):
             method, url, data = pending
-            _LOGGER.debug("AES Indiana login step %d: %s %s", step, method, url[:120])
+            # Authentication URLs contain short-lived SAML/OAuth credentials in
+            # their query strings. Keep those values out of diagnostic logs.
+            _LOGGER.debug("AES Indiana login step %d: %s %s", step, method, url.split("?", 1)[0][:120])
             async with session.request(
                 method,
                 # encoded=True keeps yarl from normalizing (and thus breaking)
@@ -122,7 +124,10 @@ class AESIndiana(UtilityBase):
             if status in (301, 302, 303, 307, 308) and location:
                 # urljoin is a pure string operation that, unlike yarl,
                 # preserves the redirect URL bytes exactly.
-                pending = ("GET", urljoin(url, location), None)
+                redirect_url = urljoin(url, location)
+                # 307 and 308 preserve the request method and body. The other
+                # redirect statuses in this browser-oriented flow become GETs.
+                pending = (method, redirect_url, data) if status in (307, 308) else ("GET", redirect_url, None)
                 continue
 
             if _LOGIN_FORM_MARKER in body:
@@ -146,7 +151,7 @@ class AESIndiana(UtilityBase):
                 pending = ("POST", urljoin(url, action_url), inputs)
                 continue
 
-            if url.startswith("https://aesi.opower.com/"):
+            if url.split("?", 1)[0].rstrip("/") == "https://aesi.opower.com/ei/x/dashboard":
                 # Landed on the OPower dashboard; session cookies are set.
                 _LOGGER.debug("AES Indiana login successful")
                 return ""

--- a/tests/opower/utilities/test_aesindiana.py
+++ b/tests/opower/utilities/test_aesindiana.py
@@ -1,0 +1,144 @@
+"""Tests for AES Indiana."""
+
+import os
+import unittest
+from typing import TYPE_CHECKING, Any, Self, cast
+
+import aiohttp
+from dotenv import load_dotenv
+from yarl import URL
+
+from opower.exceptions import InvalidAuth
+from opower.utilities.aesindiana import AESIndiana
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+ENV_SECRET_PATH = os.path.join(os.path.dirname(__file__), "../../../.env.secret")
+
+
+class _FakeResponse:
+    """Minimal asynchronous response context manager for login tests."""
+
+    def __init__(self, status: int, body: str = "", location: str | None = None) -> None:
+        self.status = status
+        self.body = body
+        self.headers: Mapping[str, str] = {"Location": location} if location else {}
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
+    async def text(self) -> str:
+        """Return the configured response body."""
+        return self.body
+
+
+class _FakeSession:
+    """Return configured responses while recording outgoing requests."""
+
+    def __init__(self, responses: list[_FakeResponse]) -> None:
+        self.responses = responses
+        self.requests: list[tuple[str, str, dict[str, str] | None]] = []
+
+    def request(
+        self,
+        method: str,
+        url: URL,
+        *,
+        data: dict[str, str] | None,
+        **kwargs: Any,
+    ) -> _FakeResponse:
+        """Record a request and return the next response."""
+        self.requests.append((method, str(url), data))
+        return self.responses.pop(0)
+
+
+class TestAESIndiana(unittest.IsolatedAsyncioTestCase):
+    """Test AES Indiana metadata and login flow behavior."""
+
+    def test_metadata(self) -> None:
+        """Return the expected utility metadata."""
+        utility = AESIndiana()
+
+        self.assertEqual("AES Indiana", utility.name())
+        self.assertEqual("aesi", utility.subdomain())
+        self.assertEqual("America/Indiana/Indianapolis", utility.timezone())
+
+    async def test_307_redirect_preserves_post_and_form_data(self) -> None:
+        """Preserve the request method and body across 307 redirects."""
+        login_form = """
+        <form action="/login">
+          <input type="hidden" name="__VIEWSTATE" value="state">
+          <input type="text" name="ctl00$phMainColumn$ctl00$iplLogin$UserName">
+        </form>
+        """
+        session = _FakeSession(
+            [
+                _FakeResponse(200, login_form),
+                _FakeResponse(307, location="/continue"),
+                _FakeResponse(200, "unexpected page"),
+            ]
+        )
+
+        with self.assertRaises(InvalidAuth):
+            await AESIndiana.async_login(cast("aiohttp.ClientSession", session), "user", "password", {})
+
+        login_request = session.requests[1]
+        redirected_request = session.requests[2]
+        self.assertEqual("POST", redirected_request[0])
+        self.assertEqual(login_request[2], redirected_request[2])
+
+    async def test_authentication_query_is_redacted_from_logs(self) -> None:
+        """Do not expose OAuth credentials in debug logs."""
+        authorization_code = "top-secret-authorization-code"
+        session = _FakeSession(
+            [
+                _FakeResponse(302, location=f"https://aesi.opower.com/ei/x/dashboard?code={authorization_code}"),
+                _FakeResponse(200),
+            ]
+        )
+
+        with self.assertLogs("opower.utilities.aesindiana", level="DEBUG") as logs:
+            token = await AESIndiana.async_login(cast("aiohttp.ClientSession", session), "user", "password", {})
+
+        self.assertEqual("", token)
+        self.assertNotIn(authorization_code, "\n".join(logs.output))
+
+    async def test_unexpected_opower_page_is_not_success(self) -> None:
+        """Reject an OPower error page that is not the dashboard."""
+        session = _FakeSession(
+            [
+                _FakeResponse(302, location="https://aesi.opower.com/ei/app/api/authenticate?error=invalid_request"),
+                _FakeResponse(200, "OAuth error"),
+            ]
+        )
+
+        with self.assertRaises(InvalidAuth):
+            await AESIndiana.async_login(cast("aiohttp.ClientSession", session), "user", "password", {})
+
+    async def test_real_login(self) -> None:
+        """Perform an optional live login against AES Indiana and OPower."""
+        load_dotenv(dotenv_path=ENV_SECRET_PATH)
+
+        username = os.getenv("AES_INDIANA_USERNAME")
+        password = os.getenv("AES_INDIANA_PASSWORD")
+        if username is None or password is None:
+            self.skipTest(
+                "Add `AES_INDIANA_USERNAME=` and `AES_INDIANA_PASSWORD=` to `.env.secret` to run the live AES Indiana test."
+            )
+
+        session = aiohttp.ClientSession()
+        self.addCleanup(session.close)
+
+        token = await AESIndiana.async_login(session, username, password, {})
+
+        self.assertEqual("", token)
+        cookies = session.cookie_jar.filter_cookies(URL("https://aesi.opower.com"))
+        self.assertTrue(cookies, "Expected authenticated OPower cookies to be set")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds AES Indiana (formerly Indianapolis Power & Light) as a supported utility. AES Indiana uses OPower at `aesi.opower.com` with Oracle IDCS SSO federated through `myaccount.aesindiana.com` via SAML.

## Utility Details

- **Subdomain**: `aesi`
- **Timezone**: `America/Indiana/Indianapolis`
- **Usage data**: Available at day/hour granularity
- **Cost data**: Only available at bill level (daily/hourly shows 0)

## How It Works

The login flow drives the ASP.NET form-based SSO redirect chain:

1. GET `aesi.opower.com/ei/` → redirects through OPower → Oracle IDCS → `myaccount.aesindiana.com`
2. POST the ASP.NET login form (ViewState + EventValidation + credentials)
3. Follow redirects back through the SAML endpoint → auto-submitting form with SAMLResponse
4. POST SAMLResponse back to Oracle IDCS → follow redirects to OPower (session established)

Uses `URL(url, encoded=True)` to preserve the signed SAMLRequest query string that yarl's normalization would otherwise break.

## Testing

Confirmed working with live AES Indiana credentials. Daily and bill-level data verified via CLI:

```bash
python -m opower --utility aesindiana --aggregate_type day --start_date 2026-07-01
python -m opower --utility aesindiana --aggregate_type bill
```

## Notes

- `myaccount.aesindiana.com` has a certificate chain issue that requires `verify=False` in the HTTP client
- The custom form parser (`_get_form_action_and_hidden_inputs`) handles HTML entity-encoded `&amp;` in form actions, which the standard `helpers.get_form_action_url_and_hidden_inputs` does not
- Follows the same pattern as NIPSCO (simple OPower utility) for the API integration, returning an empty token since authorization is cookie-based