### PR TITLE
PGE: support selecting an account when multiple are linked to one login

### DIFF
--- a/src/opower/utilities/pge.py
+++ b/src/opower/utilities/pge.py
@@ -158,6 +158,35 @@ class PGE(UtilityBase):
         """Return the timezone."""
         return "America/Los_Angeles"
 
+    @staticmethod
+    async def _async_select_account(session: aiohttp.ClientSession, aura_token: str, account_id: str) -> None:
+        """Select which billing account the Salesforce session (and thus the Opower token) is scoped to.
+
+        A PG&E login can have more than one premise linked to it (e.g. after moving, or when a
+        household account is shared). PG&E's own multi-account-v1/customers endpoint only ever
+        returns the one premise that is active in this Salesforce session at the moment the Opower
+        token is minted, not every premise linked to the login. Without an explicit selection, that
+        premise is whatever Salesforce defaults to, which is not necessarily the one the caller wants.
+
+        Reproduces the same Apex calls myaccount.pge.com's own account-switcher UI makes.
+        """
+        _LOGGER.debug("Selecting PG&E account %s before requesting Opower token", account_id)
+        for classname, method, extra_params in (
+            ("MyAcct_GlobalHeaderController", "CustomerType", {"AccNumber": account_id}),
+            ("MyAcct_AccountCacheHandler", "setBillingAccountSelection", {"ccspAccountId": account_id}),
+            ("MyAcct_AccountCacheHandler", "copyToSessionCacheForUser", None),
+        ):
+            params: dict[str, Any] = {"classname": classname, "method": method}
+            if extra_params is not None:
+                params["params"] = extra_params
+            body = {
+                "message": {"actions": [{"descriptor": "aura://ApexActionController/ACTION$execute", "params": params}]},
+                "aura.context": {"app": "siteforce:communityApp"},
+                "aura.pageURI": "/myaccount/s/",
+                "aura.token": aura_token,
+            }
+            await _aura_apex_action_execute(session, body)
+
     async def async_login(
         self,
         session: aiohttp.ClientSession,
@@ -247,6 +276,9 @@ class PGE(UtilityBase):
                 "aura.token": aura_token,
             }
             await _aura_apex_action_execute(session, body)
+
+        if account_id := login_data.get("account_id"):
+            await self._async_select_account(session, aura_token, account_id)
 
         _LOGGER.debug("Fetching OpowerDataBrowser to extract token")
         resp = await session.get(


### PR DESCRIPTION
## Problem

PG&E logins can have more than one premise linked to them. Mine still has my ex-wife's address attached from before we separated, alongside my current house. PG&E's own `multi-account-v1/customers` endpoint only ever returns one premise: whichever one is active in the myaccount.pge.com Salesforce session at the moment the Opower token gets minted. It's not pagination or a limit; the API genuinely only knows about one premise per session, and the existing login flow has no way to pick which one.

This looks related to #182, which hit the same symptom on a different utility (Portland General Electric) that runs on the same `multi-account-v1` endpoint.

## What I found

I captured the requests myaccount.pge.com's own account-switcher makes (browser devtools, HAR). Switching accounts there fires three Apex actions in sequence:

- `MyAcct_GlobalHeaderController.CustomerType` with `AccNumber`
- `MyAcct_AccountCacheHandler.setBillingAccountSelection` with `ccspAccountId`
- `MyAcct_AccountCacheHandler.copyToSessionCacheForUser` (refreshes the session cache)

Running those same three calls inside `async_login`, right after the existing login sequence and before fetching `MyAcct_VF_BillInsights_OpowerDataBrowser`, changes which premise the resulting Opower token is scoped to. I confirmed this against my own login: without the patch, `_async_get_customers()` returned my ex-wife's address; with it, it returned mine, with real usage data attached.

## The fix

`login_data` is already the channel PG&E's `async_login` uses to carry state between calls (it's how MFA cookies persist across a re-login). This adds an optional `account_id` key to that same dict. If it's set, `async_login` runs the three-call sequence above before requesting the token; if not, nothing changes.

```python
opower = Opower(session, "pge", username, password, login_data={"account_id": "1234567890"})
```

Already usable today through the CLI's `--login_data_file` flag, no CLI changes needed.

## What this doesn't fix

This lets you pick one account; it doesn't expose every account under a login at once. PG&E's API doesn't support that in a single query (`total` stays 1 no matter which account is selected). It also doesn't do anything for Home Assistant's Opower integration by itself. HA's config flow has no field for `account_id`, so getting this in front of HA users would take a separate change there.

## Testing

`ruff check`, `ruff format --check`, and `mypy` all pass on the changed file. Didn't add a unit test since none of the existing PG&E-specific paths have one either (the suite only exercises the generic invalid-auth case against live endpoints), but I'm glad to add one if there's a preferred way to mock the Apex responses.
