### PR TITLE
Use GraphQL for ConEd realtime usage

### DIFF
--- a/src/opower/opower.py
+++ b/src/opower/opower.py
@@ -218,6 +218,16 @@ class UsageRead:
     consumption: float  # taken from consumption.value field, in KWH or THERM/CCF
 
 
+@dataclasses.dataclass(frozen=True)
+class _RealtimeGraphQLMetadata:
+    """Identifiers needed to query one account's realtime GraphQL reads."""
+
+    selected_account: str
+    service_agreement_uuid: str
+    service_point_uuid: str
+    register_ids: tuple[str, ...]
+
+
 def get_supported_utilities() -> list[type["UtilityBase"]]:
     """Return a list of all supported utilities."""
     return UtilityBase.subclasses
@@ -265,6 +275,7 @@ class Opower:
         # Keyed by account uuid: meters are fetched per account, so a single
         # list would serve one account's meters for every other account.
         self._meters: dict[str, list[str]] = {}
+        self._realtime_graphql_metadata: dict[tuple[str, str, str, str], _RealtimeGraphQLMetadata | None] = {}
 
     async def async_login(self) -> None:
         """Login to the utility website and authorize opower.com for access.
@@ -632,19 +643,11 @@ class Opower:
             self._meters[account.uuid] = list(result["meters_ids"])
         return self._meters[account.uuid]
 
-    async def async_get_realtime_usage_reads(
+    async def _async_get_legacy_realtime_usage_reads(
         self,
         account: Account,
     ) -> list[UsageRead]:
-        """Get recent usage data from the "Real Time Usage" API.
-
-        The realtime API returns data in approximately the last day in 15
-        minute increments. Based on requests from ConEd, the API does not
-        accept any parameters.
-
-        Even though each account may have multiple meters, for now this
-        function only queries data for the first meter on the account.
-        """
+        """Get recent usage data from the legacy realtime REST API."""
         meters = await self._async_get_meters(account)
         if not meters:
             raise CannotConnect(f"No meters found for account {account.id}")
@@ -666,6 +669,356 @@ class Opower:
             )
             for read in result["reads"]
         ]
+
+    def _normalized_account_identifiers(self, account: Account) -> set[str]:
+        """Return account identifiers in the forms used by Opower APIs."""
+        identifiers = {account.uuid, account.utility_account_id, account.id}
+        for customer in self._customers:
+            if str(customer.get("uuid", "")) != account.customer.uuid:
+                continue
+            for utility_account in customer.get("utilityAccounts", []):
+                if str(utility_account.get("uuid", "")) != account.uuid:
+                    continue
+                identifiers |= {
+                    str(utility_account[key])
+                    for key in (
+                        "uuid",
+                        "utilityAccountId",
+                        "utilityAccountId2",
+                        "preferredUtilityAccountId",
+                        "servicePointId",
+                    )
+                    if utility_account.get(key) is not None
+                }
+        return identifiers | {identifier.lstrip("0") or "0" for identifier in identifiers}
+
+    @staticmethod
+    def _matches_meter_type(node: dict[str, Any], meter_type: MeterType) -> bool:
+        """Return whether a GraphQL service entity matches a meter type."""
+        service_type = str(node.get("serviceType", "")).upper()
+        return _DSS_SERVICE_TYPE_TO_METER.get(service_type) == meter_type.value
+
+    @staticmethod
+    def _graphql_identifiers(
+        node: dict[str, Any],
+        keys: tuple[str, ...],
+    ) -> set[str]:
+        """Return normalized identifiers from a GraphQL entity."""
+        identifiers = {str(node[key]) for key in keys if node.get(key)}
+        return identifiers | {identifier.lstrip("0") or "0" for identifier in identifiers}
+
+    def _realtime_graphql_mappings(
+        self,
+        account: Account,
+        result: dict[str, Any],
+    ) -> list[tuple[str, str, str]]:
+        """Return GraphQL account paths that safely match a REST account."""
+        account_identifiers = self._normalized_account_identifiers(account)
+        mappings: list[tuple[str, str, str]] = []
+        billing_accounts_connection = (result.get("data") or {}).get("billingAccountsConnection") or {}
+
+        for edge in billing_accounts_connection.get("edges") or []:
+            billing_account = edge.get("node") or {}
+            selected_account = str(billing_account.get("urn", ""))
+            if not selected_account:
+                continue
+
+            billing_identifiers = self._graphql_identifiers(
+                billing_account,
+                ("uuid", "accountNumber", "utilityId"),
+            )
+            billing_account_matches = bool(account_identifiers & billing_identifiers)
+
+            service_agreements_connection = billing_account.get("serviceAgreementsConnection") or {}
+            service_agreements = [
+                service_agreement_edge.get("node") or {}
+                for service_agreement_edge in service_agreements_connection.get("edges") or []
+                if self._matches_meter_type(service_agreement_edge.get("node") or {}, account.meter_type)
+            ]
+            matching_service_agreements = [
+                service_agreement
+                for service_agreement in service_agreements
+                if account_identifiers
+                & self._graphql_identifiers(
+                    service_agreement,
+                    ("uuid", "utilityId"),
+                )
+            ]
+            if matching_service_agreements:
+                service_agreements = matching_service_agreements
+            elif not billing_account_matches or len(service_agreements) != 1:
+                continue
+
+            for service_agreement in service_agreements:
+                service_points_connection = service_agreement.get("servicePointsConnection") or {}
+                service_points = [
+                    service_point_edge.get("node") or {}
+                    for service_point_edge in service_points_connection.get("edges") or []
+                    if self._matches_meter_type(service_point_edge.get("node") or {}, account.meter_type)
+                ]
+                matching_service_points = [
+                    service_point
+                    for service_point in service_points
+                    if account_identifiers
+                    & self._graphql_identifiers(
+                        service_point,
+                        ("uuid", "utilityId"),
+                    )
+                ]
+                if matching_service_points:
+                    service_points = matching_service_points
+                if len(service_points) != 1:
+                    continue
+                service_agreement_uuid = str(service_agreement.get("uuid", ""))
+                service_point_uuid = str(service_points[0].get("uuid", ""))
+                if service_agreement_uuid and service_point_uuid:
+                    mappings.append(
+                        (
+                            selected_account,
+                            service_agreement_uuid,
+                            service_point_uuid,
+                        )
+                    )
+        return mappings
+
+    async def _async_get_realtime_graphql_metadata(
+        self,
+        account: Account,
+    ) -> _RealtimeGraphQLMetadata | None:
+        """Discover and cache an unambiguous GraphQL realtime register mapping."""
+        cache_key = (
+            account.customer.uuid,
+            account.meter_type.value,
+            account.uuid,
+            account.utility_account_id,
+        )
+        if cache_key in self._realtime_graphql_metadata:
+            return self._realtime_graphql_metadata[cache_key]
+
+        topology_query = """
+        query WRTAMI_GetTopology($first: Int, $onlyActive: Boolean) {
+          billingAccountsConnection(first: $first) {
+            edges {
+              node {
+                urn
+                uuid
+                accountNumber
+                utilityId
+                serviceAgreementsConnection(first: 25, onlyActive: $onlyActive) {
+                  edges {
+                    node {
+                      uuid
+                      utilityId
+                      serviceType
+                      servicePointsConnection(first: 25) {
+                        edges {
+                          node {
+                            uuid
+                            utilityId
+                            serviceType
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        """
+        result = await self._async_post_graphql(
+            topology_query,
+            self._get_headers(account.customer.uuid),
+            {"first": 100, "onlyActive": True},
+        )
+        mappings = self._realtime_graphql_mappings(account, result)
+
+        if len(mappings) != 1:
+            self._realtime_graphql_metadata[cache_key] = None
+            return None
+
+        selected_account, service_agreement_uuid, service_point_uuid = mappings[0]
+        registers_query = """
+        query WRTAMI_GetRegisters(
+          $selectedAccount: ID
+          $saUuid: String
+          $spUuid: String
+        ) {
+          billingAccountByAuthContext(selectedAccount: $selectedAccount) {
+            serviceAgreementsConnection(onlyActive: true, matching: $saUuid) {
+              edges {
+                node {
+                  servicePointsConnection(matching: $spUuid) {
+                    edges {
+                      node {
+                        intervalReads(
+                          units: [KWH]
+                          serviceQuantityIdentifier: [NET_USAGE]
+                          onlyUnverifiedStreams: true
+                        ) {
+                          registerId
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        """
+        variables = {
+            "selectedAccount": selected_account,
+            "saUuid": service_agreement_uuid,
+            "spUuid": service_point_uuid,
+        }
+        registers_result = await self._async_post_graphql(
+            registers_query,
+            self._get_headers(account.customer.uuid),
+            variables,
+        )
+        billing_account = (registers_result.get("data") or {}).get("billingAccountByAuthContext") or {}
+        service_agreements_connection = billing_account.get("serviceAgreementsConnection") or {}
+        service_agreement_edges = service_agreements_connection.get("edges") or []
+        if len(service_agreement_edges) != 1:
+            self._realtime_graphql_metadata[cache_key] = None
+            return None
+        service_agreement = service_agreement_edges[0].get("node") or {}
+        service_points_connection = service_agreement.get("servicePointsConnection") or {}
+        service_point_edges = service_points_connection.get("edges") or []
+        if len(service_point_edges) != 1:
+            self._realtime_graphql_metadata[cache_key] = None
+            return None
+        service_point = service_point_edges[0].get("node") or {}
+        interval_reads = service_point.get("intervalReads") or []
+        register_ids = tuple(
+            dict.fromkeys(
+                str(interval_read["registerId"]) for interval_read in interval_reads if interval_read.get("registerId")
+            )
+        )
+        if not register_ids:
+            self._realtime_graphql_metadata[cache_key] = None
+            return None
+
+        metadata = _RealtimeGraphQLMetadata(
+            selected_account=selected_account,
+            service_agreement_uuid=service_agreement_uuid,
+            service_point_uuid=service_point_uuid,
+            register_ids=register_ids,
+        )
+        self._realtime_graphql_metadata[cache_key] = metadata
+        return metadata
+
+    async def _async_get_graphql_realtime_usage_reads(
+        self,
+        account: Account,
+    ) -> list[UsageRead] | None:
+        """Get recent unverified NET_USAGE reads from the GraphQL WRTAMI API."""
+        metadata = await self._async_get_realtime_graphql_metadata(account)
+        if metadata is None:
+            return None
+
+        usage_query = """
+        query WRTAMI_GetRegisterUsage(
+          $selectedAccount: ID
+          $registerId: ID
+          $saUuid: String
+          $spUuid: String
+        ) {
+          billingAccountByAuthContext(selectedAccount: $selectedAccount) {
+            serviceAgreementsConnection(onlyActive: true, matching: $saUuid) {
+              edges {
+                node {
+                  servicePointsConnection(matching: $spUuid) {
+                    edges {
+                      node {
+                        intervalReads(
+                          registerId: $registerId
+                          units: [KWH]
+                          serviceQuantityIdentifier: [NET_USAGE]
+                          onlyUnverifiedStreams: true
+                        ) {
+                          reads {
+                            timeInterval
+                            measuredAmount {
+                              value
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        """
+        tz = await aiozoneinfo.async_get_time_zone(self.utility.timezone())
+        reads: list[UsageRead] = []
+        for register_id in metadata.register_ids:
+            result = await self._async_post_graphql(
+                usage_query,
+                self._get_headers(account.customer.uuid),
+                {
+                    "selectedAccount": metadata.selected_account,
+                    "registerId": register_id,
+                    "saUuid": metadata.service_agreement_uuid,
+                    "spUuid": metadata.service_point_uuid,
+                },
+            )
+            billing_account = (result.get("data") or {}).get("billingAccountByAuthContext") or {}
+            service_agreements_connection = billing_account.get("serviceAgreementsConnection") or {}
+            service_agreement_edges = service_agreements_connection.get("edges") or []
+            if len(service_agreement_edges) != 1:
+                raise CannotConnect("GraphQL realtime service agreement mapping changed")
+            service_agreement = service_agreement_edges[0].get("node") or {}
+            service_points_connection = service_agreement.get("servicePointsConnection") or {}
+            service_point_edges = service_points_connection.get("edges") or []
+            if len(service_point_edges) != 1:
+                raise CannotConnect("GraphQL realtime service point mapping changed")
+            service_point = service_point_edges[0].get("node") or {}
+            for stream in service_point.get("intervalReads") or []:
+                for read in stream.get("reads") or []:
+                    measured_amount = read.get("measuredAmount")
+                    if not measured_amount or measured_amount.get("value") is None:
+                        continue
+                    time_interval = str(read.get("timeInterval", ""))
+                    if "/" not in time_interval:
+                        raise CannotConnect("GraphQL realtime read has an invalid time interval")
+                    start_time, end_time = time_interval.split("/", 1)
+                    reads.append(
+                        UsageRead(
+                            start_time=_parse_read_time(start_time, tz),
+                            end_time=_parse_read_time(end_time, tz),
+                            consumption=float(measured_amount["value"]),
+                        )
+                    )
+
+        if not reads:
+            raise CannotConnect("GraphQL realtime API returned no usable reads")
+        reads.sort(key=lambda read: read.start_time)
+        return reads
+
+    async def async_get_realtime_usage_reads(
+        self,
+        account: Account,
+    ) -> list[UsageRead]:
+        """Get approximately the latest day of usage in 15-minute increments."""
+        if self.utility.supports_realtime_usage():
+            try:
+                graphql_reads = await self._async_get_graphql_realtime_usage_reads(account)
+            except (ApiException, CannotConnect) as err:
+                _LOGGER.debug(
+                    "GraphQL realtime usage failed; falling back to legacy REST: %s",
+                    err,
+                )
+            else:
+                if graphql_reads is not None:
+                    return graphql_reads
+                _LOGGER.debug("GraphQL realtime account mapping was unavailable; falling back to legacy REST.")
+        return await self._async_get_legacy_realtime_usage_reads(account)
 
     async def _async_get_dated_data(
         self,
@@ -870,15 +1223,23 @@ class Opower:
         except ClientError as e:
             raise ApiException(f"Client Error: {e}", url=full_url) from e
 
-    async def _async_post_graphql(self, query: str, headers: dict[str, str]) -> Any:
+    async def _async_post_graphql(
+        self,
+        query: str,
+        headers: dict[str, str],
+        variables: dict[str, Any] | None = None,
+    ) -> Any:
         """Execute a GraphQL query against the Opower API."""
         url = f"https://{self._get_subdomain()}.opower.com/{self._get_api_root()}/edge/apis/dsm-graphql-v1/cws/graphql"
         _LOGGER.debug("GraphQL query to: %s", url)
+        payload: dict[str, Any] = {"query": query}
+        if variables is not None:
+            payload["variables"] = variables
         try:
             async with self._session.post(
                 url,
                 headers={**headers, "Content-Type": "application/json"},
-                json={"query": query},
+                json=payload,
             ) as resp:
                 if not resp.ok:
                     raise ApiException(

--- a/src/opower/opower.py
+++ b/src/opower/opower.py
@@ -1122,7 +1122,7 @@ class Opower:
         unique_nodes: list[dict[str, Any]] = []
         seen_uuids: set[str] = set()
         for node in nodes:
-            uuid = str(node.get("uuid", ""))
+            uuid = str(node.get("uuid") or "")
             if uuid and uuid in seen_uuids:
                 continue
             unique_nodes.append(node)
@@ -1144,7 +1144,7 @@ class Opower:
 
         for edge in billing_accounts_connection.get("edges") or []:
             billing_account = edge.get("node") or {}
-            selected_account = str(billing_account.get("urn", ""))
+            selected_account = str(billing_account.get("urn") or "")
             if not selected_account:
                 continue
 
@@ -1189,8 +1189,8 @@ class Opower:
                     service_points = matching_service_points
                 if len(service_points) != 1:
                     continue
-                service_agreement_uuid = str(service_agreement.get("uuid", ""))
-                service_point_uuid = str(service_points[0].get("uuid", ""))
+                service_agreement_uuid = str(service_agreement.get("uuid") or "")
+                service_point_uuid = str(service_points[0].get("uuid") or "")
                 if service_agreement_uuid and service_point_uuid:
                     mappings.append(
                         (
@@ -1201,17 +1201,32 @@ class Opower:
                     )
         return list(dict.fromkeys(mappings))
 
-    async def _async_get_realtime_graphql_metadata(
-        self,
-        account: Account,
-    ) -> _RealtimeGraphQLMetadata | None:
-        """Discover and cache an unambiguous GraphQL realtime register mapping."""
-        cache_key = (
+    @staticmethod
+    def _realtime_graphql_cache_key(account: Account) -> tuple[str, str, str, str]:
+        """Return the key the discovered realtime mapping is cached under."""
+        return (
             account.customer.uuid,
             account.meter_type.value,
             account.uuid,
             account.utility_account_id,
         )
+
+    def _forget_realtime_graphql_metadata(self, account: Account) -> None:
+        """Drop the cached mapping so the next call rediscovers it.
+
+        The mapping is discovered once and reused. When the usage query then finds
+        it no longer resolves - a replaced meter or service agreement - keeping it
+        would repeat the same doomed request on every later call for the life of
+        the session, while rediscovery would have fixed it.
+        """
+        self._realtime_graphql_metadata.pop(self._realtime_graphql_cache_key(account), None)
+
+    async def _async_get_realtime_graphql_metadata(
+        self,
+        account: Account,
+    ) -> _RealtimeGraphQLMetadata | None:
+        """Discover and cache an unambiguous GraphQL realtime register mapping."""
+        cache_key = self._realtime_graphql_cache_key(account)
         if cache_key in self._realtime_graphql_metadata:
             return self._realtime_graphql_metadata[cache_key]
 
@@ -1261,7 +1276,13 @@ class Opower:
         mappings = self._realtime_graphql_mappings(account, result)
 
         if len(mappings) != 1:
-            self._realtime_graphql_metadata[cache_key] = None
+            # Only remember "no mapping" when the response actually described the
+            # customer. An empty body is more likely a server hiccup than an
+            # account without a realtime stream, and caching it would pin this
+            # utility to the legacy REST endpoint - the one that now returns 424 -
+            # until the next restart.
+            if ((result.get("data") or {}).get("billingAccountsConnection") or {}).get("edges"):
+                self._realtime_graphql_metadata[cache_key] = None
             return None
 
         selected_account, service_agreement_uuid, service_point_uuid = mappings[0]
@@ -1357,6 +1378,13 @@ class Opower:
 
         # Observed on ConEd 2026-09-01: omitting timeInterval returns the latest
         # ~24 hours; explicit requests are also capped at 24 hours (dasl-/pitools#15).
+        #
+        # intervalReads on purpose, even though the historical read path deliberately
+        # avoids it (see _REGISTER_READS_QUERY). Its two drawbacks - the 24 hour cap
+        # and null values around DST transitions - are what rule it out for a long
+        # backfill, and neither bites a rolling ~24 hour realtime window. It is also
+        # the only field taking onlyUnverifiedStreams, which is what makes these
+        # reads ~50 minutes fresh rather than hours. Do not "fix" this to readStreams.
         usage_query = """
         query WRTAMI_GetRegisterUsage(
           $selectedAccount: ID
@@ -1409,31 +1437,40 @@ class Opower:
         service_agreements_connection = billing_account.get("serviceAgreementsConnection") or {}
         service_agreement_edges = service_agreements_connection.get("edges") or []
         if len(service_agreement_edges) != 1:
+            self._forget_realtime_graphql_metadata(account)
             raise CannotConnect("GraphQL realtime service agreement mapping changed")
         service_agreement = service_agreement_edges[0].get("node") or {}
         service_points_connection = service_agreement.get("servicePointsConnection") or {}
         service_point_edges = service_points_connection.get("edges") or []
         if len(service_point_edges) != 1:
+            self._forget_realtime_graphql_metadata(account)
             raise CannotConnect("GraphQL realtime service point mapping changed")
         service_point = service_point_edges[0].get("node") or {}
         streams = service_point.get("intervalReads") or []
         if len(streams) != 1:
+            self._forget_realtime_graphql_metadata(account)
             raise CannotConnect("GraphQL realtime register mapping changed")
         for read in streams[0].get("reads") or []:
             measured_amount = read.get("measuredAmount")
             if not measured_amount or measured_amount.get("value") is None:
                 continue
-            time_interval = str(read.get("timeInterval", ""))
+            time_interval = str(read.get("timeInterval") or "")
             if "/" not in time_interval:
                 raise CannotConnect("GraphQL realtime read has an invalid time interval")
             start_time, end_time = time_interval.split("/", 1)
-            reads.append(
-                UsageRead(
-                    start_time=_parse_read_time(start_time, tz),
-                    end_time=_parse_read_time(end_time, tz),
-                    consumption=float(measured_amount["value"]),
+            try:
+                reads.append(
+                    UsageRead(
+                        start_time=_parse_read_time(start_time, tz),
+                        end_time=_parse_read_time(end_time, tz),
+                        consumption=float(measured_amount["value"]),
+                    )
                 )
-            )
+            except (TypeError, ValueError) as err:
+                # Anything unparsable is a changed contract, not a bad read. Raise
+                # so the caller falls back to REST rather than returning a series
+                # with holes in it.
+                raise CannotConnect(f"GraphQL realtime read could not be parsed: {err}") from err
 
         reads.sort(key=lambda read: read.start_time)
         return reads
@@ -1447,7 +1484,10 @@ class Opower:
         Interval resolution varies by utility. The compatibility REST path
         queries only the account's first meter.
         """
-        if self.utility.supports_realtime_usage():
+        # Both GraphQL queries ask for KWH registers, so a gas or water account
+        # would spend two round trips to discover nothing; the legacy REST path
+        # serves those meters unchanged.
+        if self.utility.supports_realtime_usage() and account.meter_type is MeterType.ELEC:
             try:
                 graphql_reads = await self._async_get_graphql_realtime_usage_reads(account)
             except (ApiException, CannotConnect) as err:

--- a/src/opower/opower.py
+++ b/src/opower/opower.py
@@ -647,7 +647,7 @@ class Opower:
         self,
         account: Account,
     ) -> list[UsageRead]:
-        """Get recent usage data from the legacy realtime REST API."""
+        """Get recent legacy REST usage from the account's first meter."""
         meters = await self._async_get_meters(account)
         if not meters:
             raise CannotConnect(f"No meters found for account {account.id}")
@@ -715,6 +715,27 @@ class Opower:
         identifiers = {str(node[key]) for key in keys if node.get(key)}
         return identifiers | {identifier.lstrip("0") or "0" for identifier in identifiers}
 
+    @staticmethod
+    def _graphql_connection_is_complete(connection: dict[str, Any]) -> bool:
+        """Return whether a requested GraphQL connection is not truncated."""
+        return (connection.get("pageInfo") or {}).get("hasNextPage") is False
+
+    @staticmethod
+    def _deduplicate_graphql_nodes_by_uuid(
+        nodes: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        """Deduplicate GraphQL nodes only when they share a non-empty UUID."""
+        unique_nodes: list[dict[str, Any]] = []
+        seen_uuids: set[str] = set()
+        for node in nodes:
+            uuid = str(node.get("uuid", ""))
+            if uuid and uuid in seen_uuids:
+                continue
+            unique_nodes.append(node)
+            if uuid:
+                seen_uuids.add(uuid)
+        return unique_nodes
+
     def _realtime_graphql_mappings(
         self,
         account: Account,
@@ -724,6 +745,8 @@ class Opower:
         account_identifiers = self._normalized_account_identifiers(account)
         mappings: list[tuple[str, str, str]] = []
         billing_accounts_connection = (result.get("data") or {}).get("billingAccountsConnection") or {}
+        if not self._graphql_connection_is_complete(billing_accounts_connection):
+            return []
 
         for edge in billing_accounts_connection.get("edges") or []:
             billing_account = edge.get("node") or {}
@@ -732,6 +755,8 @@ class Opower:
                 continue
 
             service_agreements_connection = billing_account.get("serviceAgreementsConnection") or {}
+            if not self._graphql_connection_is_complete(service_agreements_connection):
+                return []
             service_agreements = [
                 service_agreement_edge.get("node") or {}
                 for service_agreement_edge in service_agreements_connection.get("edges") or []
@@ -749,11 +774,14 @@ class Opower:
 
             for service_agreement in service_agreements:
                 service_points_connection = service_agreement.get("servicePointsConnection") or {}
+                if not self._graphql_connection_is_complete(service_points_connection):
+                    return []
                 service_points = [
                     service_point_edge.get("node") or {}
                     for service_point_edge in service_points_connection.get("edges") or []
                     if self._matches_meter_type(service_point_edge.get("node") or {}, account.meter_type)
                 ]
+                service_points = self._deduplicate_graphql_nodes_by_uuid(service_points)
                 matching_service_points = [
                     service_point
                     for service_point in service_points
@@ -777,7 +805,7 @@ class Opower:
                             service_point_uuid,
                         )
                     )
-        return mappings
+        return list(dict.fromkeys(mappings))
 
     async def _async_get_realtime_graphql_metadata(
         self,
@@ -796,16 +824,25 @@ class Opower:
         topology_query = """
         query WRTAMI_GetTopology($first: Int, $onlyActive: Boolean) {
           billingAccountsConnection(first: $first) {
+            pageInfo {
+              hasNextPage
+            }
             edges {
               node {
                 urn
-                serviceAgreementsConnection(first: 25, onlyActive: $onlyActive) {
+                serviceAgreementsConnection(first: $first, onlyActive: $onlyActive) {
+                  pageInfo {
+                    hasNextPage
+                  }
                   edges {
                     node {
                       uuid
                       utilityId
                       serviceType
-                      servicePointsConnection(first: 25) {
+                      servicePointsConnection(first: $first) {
+                        pageInfo {
+                          hasNextPage
+                        }
                         edges {
                           node {
                             uuid
@@ -892,7 +929,17 @@ class Opower:
                 str(interval_read["registerId"]) for interval_read in interval_reads if interval_read.get("registerId")
             )
         )
-        if len(register_ids) != 1:
+        net_usage_register_ids = [
+            register_id for register_id in register_ids if "NET_USAGE" in register_id.strip().upper().split(":")
+        ]
+        if len(net_usage_register_ids) == 1:
+            register_id = net_usage_register_ids[0]
+        elif len(register_ids) == 1 and not {
+            "DELIVERED",
+            "RECEIVED",
+        } & set(register_ids[0].strip().upper().split(":")):
+            register_id = register_ids[0]
+        else:
             self._realtime_graphql_metadata[cache_key] = None
             return None
 
@@ -900,7 +947,7 @@ class Opower:
             selected_account=selected_account,
             service_agreement_uuid=service_agreement_uuid,
             service_point_uuid=service_point_uuid,
-            register_id=register_ids[0],
+            register_id=register_id,
         )
         self._realtime_graphql_metadata[cache_key] = metadata
         return metadata
@@ -914,6 +961,8 @@ class Opower:
         if metadata is None:
             return None
 
+        # Observed on ConEd 2026-09-01: omitting timeInterval returns the latest
+        # ~24 hours; explicit requests are also capped at 24 hours (dasl-/pitools#15).
         usage_query = """
         query WRTAMI_GetRegisterUsage(
           $selectedAccount: ID
@@ -992,8 +1041,6 @@ class Opower:
                 )
             )
 
-        if not reads:
-            raise CannotConnect("GraphQL realtime API returned no usable reads")
         reads.sort(key=lambda read: read.start_time)
         return reads
 
@@ -1001,7 +1048,11 @@ class Opower:
         self,
         account: Account,
     ) -> list[UsageRead]:
-        """Get approximately the latest day of usage in 15-minute increments."""
+        """Get approximately the latest day of realtime usage.
+
+        Interval resolution varies by utility. The compatibility REST path
+        queries only the account's first meter.
+        """
         if self.utility.supports_realtime_usage():
             try:
                 graphql_reads = await self._async_get_graphql_realtime_usage_reads(account)

--- a/src/opower/opower.py
+++ b/src/opower/opower.py
@@ -225,7 +225,7 @@ class _RealtimeGraphQLMetadata:
     selected_account: str
     service_agreement_uuid: str
     service_point_uuid: str
-    register_ids: tuple[str, ...]
+    register_id: str
 
 
 def get_supported_utilities() -> list[type["UtilityBase"]]:
@@ -672,7 +672,15 @@ class Opower:
 
     def _normalized_account_identifiers(self, account: Account) -> set[str]:
         """Return account identifiers in the forms used by Opower APIs."""
-        identifiers = {account.uuid, account.utility_account_id, account.id}
+        identifiers = {
+            identifier
+            for identifier in (
+                account.uuid,
+                account.utility_account_id,
+                account.id,
+            )
+            if identifier
+        }
         for customer in self._customers:
             if str(customer.get("uuid", "")) != account.customer.uuid:
                 continue
@@ -723,19 +731,13 @@ class Opower:
             if not selected_account:
                 continue
 
-            billing_identifiers = self._graphql_identifiers(
-                billing_account,
-                ("uuid", "accountNumber", "utilityId"),
-            )
-            billing_account_matches = bool(account_identifiers & billing_identifiers)
-
             service_agreements_connection = billing_account.get("serviceAgreementsConnection") or {}
             service_agreements = [
                 service_agreement_edge.get("node") or {}
                 for service_agreement_edge in service_agreements_connection.get("edges") or []
                 if self._matches_meter_type(service_agreement_edge.get("node") or {}, account.meter_type)
             ]
-            matching_service_agreements = [
+            service_agreements = [
                 service_agreement
                 for service_agreement in service_agreements
                 if account_identifiers
@@ -744,10 +746,6 @@ class Opower:
                     ("uuid", "utilityId"),
                 )
             ]
-            if matching_service_agreements:
-                service_agreements = matching_service_agreements
-            elif not billing_account_matches or len(service_agreements) != 1:
-                continue
 
             for service_agreement in service_agreements:
                 service_points_connection = service_agreement.get("servicePointsConnection") or {}
@@ -801,9 +799,6 @@ class Opower:
             edges {
               node {
                 urn
-                uuid
-                accountNumber
-                utilityId
                 serviceAgreementsConnection(first: 25, onlyActive: $onlyActive) {
                   edges {
                     node {
@@ -897,7 +892,7 @@ class Opower:
                 str(interval_read["registerId"]) for interval_read in interval_reads if interval_read.get("registerId")
             )
         )
-        if not register_ids:
+        if len(register_ids) != 1:
             self._realtime_graphql_metadata[cache_key] = None
             return None
 
@@ -905,7 +900,7 @@ class Opower:
             selected_account=selected_account,
             service_agreement_uuid=service_agreement_uuid,
             service_point_uuid=service_point_uuid,
-            register_ids=register_ids,
+            register_id=register_ids[0],
         )
         self._realtime_graphql_metadata[cache_key] = metadata
         return metadata
@@ -957,44 +952,45 @@ class Opower:
         """
         tz = await aiozoneinfo.async_get_time_zone(self.utility.timezone())
         reads: list[UsageRead] = []
-        for register_id in metadata.register_ids:
-            result = await self._async_post_graphql(
-                usage_query,
-                self._get_headers(account.customer.uuid),
-                {
-                    "selectedAccount": metadata.selected_account,
-                    "registerId": register_id,
-                    "saUuid": metadata.service_agreement_uuid,
-                    "spUuid": metadata.service_point_uuid,
-                },
+        result = await self._async_post_graphql(
+            usage_query,
+            self._get_headers(account.customer.uuid),
+            {
+                "selectedAccount": metadata.selected_account,
+                "registerId": metadata.register_id,
+                "saUuid": metadata.service_agreement_uuid,
+                "spUuid": metadata.service_point_uuid,
+            },
+        )
+        billing_account = (result.get("data") or {}).get("billingAccountByAuthContext") or {}
+        service_agreements_connection = billing_account.get("serviceAgreementsConnection") or {}
+        service_agreement_edges = service_agreements_connection.get("edges") or []
+        if len(service_agreement_edges) != 1:
+            raise CannotConnect("GraphQL realtime service agreement mapping changed")
+        service_agreement = service_agreement_edges[0].get("node") or {}
+        service_points_connection = service_agreement.get("servicePointsConnection") or {}
+        service_point_edges = service_points_connection.get("edges") or []
+        if len(service_point_edges) != 1:
+            raise CannotConnect("GraphQL realtime service point mapping changed")
+        service_point = service_point_edges[0].get("node") or {}
+        streams = service_point.get("intervalReads") or []
+        if len(streams) != 1:
+            raise CannotConnect("GraphQL realtime register mapping changed")
+        for read in streams[0].get("reads") or []:
+            measured_amount = read.get("measuredAmount")
+            if not measured_amount or measured_amount.get("value") is None:
+                continue
+            time_interval = str(read.get("timeInterval", ""))
+            if "/" not in time_interval:
+                raise CannotConnect("GraphQL realtime read has an invalid time interval")
+            start_time, end_time = time_interval.split("/", 1)
+            reads.append(
+                UsageRead(
+                    start_time=_parse_read_time(start_time, tz),
+                    end_time=_parse_read_time(end_time, tz),
+                    consumption=float(measured_amount["value"]),
+                )
             )
-            billing_account = (result.get("data") or {}).get("billingAccountByAuthContext") or {}
-            service_agreements_connection = billing_account.get("serviceAgreementsConnection") or {}
-            service_agreement_edges = service_agreements_connection.get("edges") or []
-            if len(service_agreement_edges) != 1:
-                raise CannotConnect("GraphQL realtime service agreement mapping changed")
-            service_agreement = service_agreement_edges[0].get("node") or {}
-            service_points_connection = service_agreement.get("servicePointsConnection") or {}
-            service_point_edges = service_points_connection.get("edges") or []
-            if len(service_point_edges) != 1:
-                raise CannotConnect("GraphQL realtime service point mapping changed")
-            service_point = service_point_edges[0].get("node") or {}
-            for stream in service_point.get("intervalReads") or []:
-                for read in stream.get("reads") or []:
-                    measured_amount = read.get("measuredAmount")
-                    if not measured_amount or measured_amount.get("value") is None:
-                        continue
-                    time_interval = str(read.get("timeInterval", ""))
-                    if "/" not in time_interval:
-                        raise CannotConnect("GraphQL realtime read has an invalid time interval")
-                    start_time, end_time = time_interval.split("/", 1)
-                    reads.append(
-                        UsageRead(
-                            start_time=_parse_read_time(start_time, tz),
-                            end_time=_parse_read_time(end_time, tz),
-                            consumption=float(measured_amount["value"]),
-                        )
-                    )
 
         if not reads:
             raise CannotConnect("GraphQL realtime API returned no usable reads")

--- a/tests/test_opower.py
+++ b/tests/test_opower.py
@@ -1,6 +1,7 @@
 """Tests for Opower."""
 
 import asyncio
+import dataclasses
 import json
 from datetime import date, datetime, timedelta
 from typing import TYPE_CHECKING, Any
@@ -2334,6 +2335,181 @@ async def test_realtime_usage_reads_fall_back_when_graphql_mapping_is_ambiguous(
     assert second == first
     assert topology_calls == 1
     assert [request["method"] for request in session.requests] == ["GET", "GET", "GET"]
+
+
+@pytest.mark.asyncio
+async def test_realtime_discovery_is_not_disabled_by_an_empty_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An empty topology body is a hiccup, not an account without a stream.
+
+    Caching it would pin the utility to the legacy REST endpoint - the one that
+    now returns 424 - until the next restart.
+    """
+    meters_response = {"meters_ids": ["KWH:NET_USAGE"]}
+    rest_usage = {"reads": [{"startTime": "2026-09-01T10:00:00-04:00", "endTime": "2026-09-01T10:15:00-04:00", "value": 0.4}]}
+    session = _FakeSession({"/meters/": rest_usage, "/meters": meters_response})
+    opower = _coned(session)
+    account = _realtime_account()
+    calls = 0
+
+    async def fake_post_graphql(
+        query: str,
+        headers: dict[str, str],
+        variables: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        nonlocal calls
+        del headers, variables
+        calls += 1
+        if calls == 1:
+            return {"data": {"billingAccountsConnection": None}}
+        if "WRTAMI_GetTopology" in query:
+            return _realtime_topology(
+                _realtime_billing_account(
+                    "billing-1",
+                    "service-agreement-1",
+                    service_agreement_utility_id=account.utility_account_id,
+                )
+            )
+        if "WRTAMI_GetRegisters" in query:
+            return _realtime_registers("KWH:NET_USAGE")
+        return _realtime_usage(
+            {
+                "timeInterval": "2026-09-01T14:00:00Z/2026-09-01T14:15:00Z",
+                "measuredAmount": {"value": 0.25},
+            }
+        )
+
+    monkeypatch.setattr(opower, "_async_post_graphql", fake_post_graphql)
+
+    first = await opower.async_get_realtime_usage_reads(account)
+    second = await opower.async_get_realtime_usage_reads(account)
+
+    assert [read.consumption for read in first] == [0.4], "empty body falls back to REST"
+    assert [read.consumption for read in second] == [0.25], "and must retry GraphQL next time"
+
+
+@pytest.mark.asyncio
+async def test_realtime_usage_reads_rediscover_after_the_mapping_changes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cached mapping that stops resolving is dropped, not retried forever."""
+    meters_response = {"meters_ids": ["KWH:NET_USAGE"]}
+    rest_usage = {"reads": [{"startTime": "2026-09-01T10:00:00-04:00", "endTime": "2026-09-01T10:15:00-04:00", "value": 0.4}]}
+    session = _FakeSession({"/meters/": rest_usage, "/meters": meters_response})
+    opower = _coned(session)
+    account = _realtime_account()
+    topology_calls = 0
+    usage_calls = 0
+
+    async def fake_post_graphql(
+        query: str,
+        headers: dict[str, str],
+        variables: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        nonlocal topology_calls, usage_calls
+        del headers, variables
+        if "WRTAMI_GetTopology" in query:
+            topology_calls += 1
+            return _realtime_topology(
+                _realtime_billing_account(
+                    "billing-1",
+                    "service-agreement-1",
+                    service_agreement_utility_id=account.utility_account_id,
+                )
+            )
+        if "WRTAMI_GetRegisters" in query:
+            return _realtime_registers("KWH:NET_USAGE")
+        usage_calls += 1
+        if usage_calls == 1:
+            # The register the mapping was built on has gone away.
+            return {"data": {"billingAccountByAuthContext": {"serviceAgreementsConnection": {"edges": []}}}}
+        return _realtime_usage(
+            {
+                "timeInterval": "2026-09-01T14:00:00Z/2026-09-01T14:15:00Z",
+                "measuredAmount": {"value": 0.25},
+            }
+        )
+
+    monkeypatch.setattr(opower, "_async_post_graphql", fake_post_graphql)
+
+    first = await opower.async_get_realtime_usage_reads(account)
+    second = await opower.async_get_realtime_usage_reads(account)
+
+    assert [read.consumption for read in first] == [0.4], "a changed mapping falls back to REST"
+    assert [read.consumption for read in second] == [0.25]
+    assert topology_calls == 2, "the stale mapping must be rediscovered, not reused"
+
+
+@pytest.mark.asyncio
+async def test_realtime_usage_reads_skip_graphql_for_non_electric_meters(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both GraphQL queries ask for KWH, so a gas meter must not pay for them."""
+    meters_response = {"meters_ids": ["THERM:NET_USAGE"]}
+    rest_usage = {"reads": [{"startTime": "2026-09-01T10:00:00-04:00", "endTime": "2026-09-01T10:15:00-04:00", "value": 0.4}]}
+    session = _FakeSession({"/meters/": rest_usage, "/meters": meters_response})
+    opower = _coned(session)
+    gas_account = dataclasses.replace(_realtime_account(), meter_type=MeterType.GAS)
+    calls = 0
+
+    async def fake_post_graphql(
+        query: str,
+        headers: dict[str, str],
+        variables: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        nonlocal calls
+        del query, headers, variables
+        calls += 1
+        return {}
+
+    monkeypatch.setattr(opower, "_async_post_graphql", fake_post_graphql)
+
+    result = await opower.async_get_realtime_usage_reads(gas_account)
+
+    assert [read.consumption for read in result] == [0.4]
+    assert calls == 0, "no GraphQL round trip for a meter the queries cannot serve"
+
+
+@pytest.mark.asyncio
+async def test_realtime_usage_reads_fall_back_on_an_unparsable_read(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A read that will not parse must fall back, not raise at the caller."""
+    meters_response = {"meters_ids": ["KWH:NET_USAGE"]}
+    rest_usage = {"reads": [{"startTime": "2026-09-01T10:00:00-04:00", "endTime": "2026-09-01T10:15:00-04:00", "value": 0.4}]}
+    session = _FakeSession({"/meters/": rest_usage, "/meters": meters_response})
+    opower = _coned(session)
+    account = _realtime_account()
+
+    async def fake_post_graphql(
+        query: str,
+        headers: dict[str, str],
+        variables: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        del headers, variables
+        if "WRTAMI_GetTopology" in query:
+            return _realtime_topology(
+                _realtime_billing_account(
+                    "billing-1",
+                    "service-agreement-1",
+                    service_agreement_utility_id=account.utility_account_id,
+                )
+            )
+        if "WRTAMI_GetRegisters" in query:
+            return _realtime_registers("KWH:NET_USAGE")
+        return _realtime_usage(
+            {
+                "timeInterval": "not-a-timestamp/also-not-a-timestamp",
+                "measuredAmount": {"value": 0.25},
+            }
+        )
+
+    monkeypatch.setattr(opower, "_async_post_graphql", fake_post_graphql)
+
+    result = await opower.async_get_realtime_usage_reads(account)
+
+    assert [read.consumption for read in result] == [0.4]
 
 
 @pytest.mark.asyncio

--- a/tests/test_opower.py
+++ b/tests/test_opower.py
@@ -613,6 +613,18 @@ def _pge(session: _FakeSession) -> Opower:
     return opower
 
 
+def _coned(session: _FakeSession) -> Opower:
+    """Return a ConEd client wired to a fake session and already logged in."""
+    opower = Opower(
+        session,  # type: ignore[arg-type]
+        "Consolidated Edison (ConEd)",
+        "test",
+        "test",
+    )
+    opower._access_token = _ACCESS_TOKEN
+    return opower
+
+
 @pytest.mark.asyncio
 async def test_get_accounts_parses_customers_response() -> None:
     """Parse accounts out of a multi-account-v1 response."""
@@ -1241,6 +1253,290 @@ async def test_realtime_usage_reads_require_a_meter() -> None:
 
     with pytest.raises(CannotConnect):
         await _pge(session).async_get_realtime_usage_reads(account)
+
+
+def _realtime_account() -> Account:
+    """Return a synthetic ConEd electric account."""
+    return Account(
+        customer=Customer(uuid=_CUSTOMER_UUID),
+        uuid=_ELEC_ACCOUNT_UUID,
+        utility_account_id="1000000003",
+        id="1000000003",
+        meter_type=MeterType.ELEC,
+        read_resolution=ReadResolution.QUARTER_HOUR,
+    )
+
+
+def _realtime_topology(*billing_accounts: dict[str, Any]) -> dict[str, Any]:
+    """Build a GraphQL billing account topology response."""
+    return {
+        "data": {"billingAccountsConnection": {"edges": [{"node": billing_account} for billing_account in billing_accounts]}}
+    }
+
+
+def _realtime_billing_account(
+    billing_uuid: str,
+    service_agreement_uuid: str,
+    *,
+    account_number: str = "1000000003",
+    service_agreement_utility_id: str | None = None,
+) -> dict[str, Any]:
+    """Build one GraphQL billing account with an electric service point."""
+    return {
+        "urn": f"urn:opower:v1:account:cned:uuid:{billing_uuid}",
+        "uuid": billing_uuid,
+        "accountNumber": account_number,
+        "utilityId": account_number,
+        "serviceAgreementsConnection": {
+            "edges": [
+                {
+                    "node": {
+                        "uuid": service_agreement_uuid,
+                        "utilityId": service_agreement_utility_id,
+                        "serviceType": "ELECTRICITY",
+                        "servicePointsConnection": {
+                            "edges": [
+                                {
+                                    "node": {
+                                        "uuid": f"sp-{service_agreement_uuid}",
+                                        "serviceType": "ELECTRICITY",
+                                    }
+                                }
+                            ]
+                        },
+                    }
+                }
+            ]
+        },
+    }
+
+
+def _realtime_registers(*register_ids: str) -> dict[str, Any]:
+    """Build a GraphQL WRTAMI register response."""
+    return {
+        "data": {
+            "billingAccountByAuthContext": {
+                "serviceAgreementsConnection": {
+                    "edges": [
+                        {
+                            "node": {
+                                "servicePointsConnection": {
+                                    "edges": [
+                                        {
+                                            "node": {
+                                                "intervalReads": [{"registerId": register_id} for register_id in register_ids]
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    }
+
+
+def _realtime_usage(*reads: dict[str, Any]) -> dict[str, Any]:
+    """Build a GraphQL WRTAMI usage response."""
+    return {
+        "data": {
+            "billingAccountByAuthContext": {
+                "serviceAgreementsConnection": {
+                    "edges": [
+                        {
+                            "node": {
+                                "servicePointsConnection": {"edges": [{"node": {"intervalReads": [{"reads": list(reads)}]}}]}
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_realtime_usage_reads_use_graphql_net_usage_and_cache_discovery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ConEd uses unverified NET_USAGE reads and caches stable register metadata."""
+    opower = _coned(_FakeSession({}))
+    account = _realtime_account()
+    calls: list[tuple[str, dict[str, Any] | None]] = []
+
+    async def fake_post_graphql(
+        query: str,
+        headers: dict[str, str],
+        variables: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        del headers
+        calls.append((query, variables))
+        if "WRTAMI_GetTopology" in query:
+            return _realtime_topology(
+                _realtime_billing_account(
+                    "other-billing-account",
+                    "other-service-agreement",
+                    account_number="9999999999",
+                ),
+                _realtime_billing_account(
+                    "selected-billing-account",
+                    "selected-service-agreement",
+                    account_number="9999999998",
+                    service_agreement_utility_id=account.utility_account_id,
+                ),
+            )
+        if "WRTAMI_GetRegisters" in query:
+            return _realtime_registers("net-register")
+        return _realtime_usage(
+            {
+                "timeInterval": "2026-09-01T10:15:00-04:00/2026-09-01T10:30:00-04:00",
+                "measuredAmount": {"value": -0.12},
+            },
+            {
+                "timeInterval": "2026-09-01T10:00:00-04:00/2026-09-01T10:15:00-04:00",
+                "measuredAmount": {"value": 0.25},
+            },
+            {
+                "timeInterval": "2026-09-01T10:30:00-04:00/2026-09-01T10:45:00-04:00",
+                "measuredAmount": None,
+            },
+        )
+
+    monkeypatch.setattr(opower, "_async_post_graphql", fake_post_graphql)
+
+    first = await opower.async_get_realtime_usage_reads(account)
+    second = await opower.async_get_realtime_usage_reads(account)
+
+    assert [read.consumption for read in first] == [0.25, -0.12]
+    assert second == first
+    assert first[0].start_time == datetime(2026, 9, 1, 10, 0, tzinfo=ZoneInfo("America/New_York"))
+    assert sum("WRTAMI_GetTopology" in query for query, _ in calls) == 1
+    assert sum("WRTAMI_GetRegisters" in query for query, _ in calls) == 1
+    assert sum("WRTAMI_GetRegisterUsage" in query for query, _ in calls) == 2
+    realtime_queries = [query for query, _ in calls if "WRTAMI_GetRegisters" in query or "WRTAMI_GetRegisterUsage" in query]
+    assert all("serviceQuantityIdentifier: [NET_USAGE]" in query for query in realtime_queries)
+    assert all("onlyUnverifiedStreams: true" in query for query in realtime_queries)
+    usage_variables = next(variables for query, variables in calls if "WRTAMI_GetRegisterUsage" in query)
+    assert usage_variables == {
+        "selectedAccount": ("urn:opower:v1:account:cned:uuid:selected-billing-account"),
+        "registerId": "net-register",
+        "saUuid": "selected-service-agreement",
+        "spUuid": "sp-selected-service-agreement",
+    }
+
+
+@pytest.mark.asyncio
+async def test_realtime_usage_reads_fall_back_when_graphql_mapping_is_ambiguous(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Multiple matching GraphQL account paths use the compatibility REST API."""
+    meters_response = {"meters_ids": ["KWH:NET_USAGE"]}
+    usage_response = {
+        "reads": [
+            {
+                "startTime": "2026-09-01T10:00:00-04:00",
+                "endTime": "2026-09-01T10:15:00-04:00",
+                "value": 0.4,
+            }
+        ]
+    }
+    session = _FakeSession({"/meters/": usage_response, "/meters": meters_response})
+    opower = _coned(session)
+    account = _realtime_account()
+    topology_calls = 0
+
+    async def fake_post_graphql(
+        query: str,
+        headers: dict[str, str],
+        variables: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        nonlocal topology_calls
+        del query, headers, variables
+        topology_calls += 1
+        return _realtime_topology(
+            _realtime_billing_account("billing-1", "service-agreement-1"),
+            _realtime_billing_account("billing-2", "service-agreement-2"),
+        )
+
+    monkeypatch.setattr(opower, "_async_post_graphql", fake_post_graphql)
+
+    first = await opower.async_get_realtime_usage_reads(account)
+    second = await opower.async_get_realtime_usage_reads(account)
+
+    assert [read.consumption for read in first] == [0.4]
+    assert second == first
+    assert topology_calls == 1
+    assert [request["method"] for request in session.requests] == ["GET", "GET", "GET"]
+
+
+@pytest.mark.asyncio
+async def test_realtime_usage_reads_fall_back_when_graphql_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A GraphQL API failure uses the existing realtime REST path."""
+    session = _FakeSession(
+        {
+            "/meters/": {
+                "reads": [
+                    {
+                        "startTime": "2026-09-01T10:00:00-04:00",
+                        "endTime": "2026-09-01T10:15:00-04:00",
+                        "value": 0.4,
+                    }
+                ]
+            },
+            "/meters": {"meters_ids": ["KWH:NET_USAGE"]},
+        }
+    )
+    opower = _coned(session)
+
+    async def fail_graphql(
+        query: str,
+        headers: dict[str, str],
+        variables: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        del query, headers, variables
+        raise ApiException("GraphQL failed", url="https://example.test/graphql")
+
+    monkeypatch.setattr(opower, "_async_post_graphql", fail_graphql)
+
+    result = await opower.async_get_realtime_usage_reads(_realtime_account())
+
+    assert [read.consumption for read in result] == [0.4]
+
+
+@pytest.mark.asyncio
+async def test_realtime_usage_reads_surface_rest_error_after_graphql_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The compatibility REST error propagates when both realtime paths fail."""
+    session = _FakeSession(
+        {
+            "/meters": _FakeResponse(
+                {"error": {"details": "No meter asset ID returned"}},
+                status=424,
+            )
+        }
+    )
+    opower = _coned(session)
+
+    async def fail_graphql(
+        query: str,
+        headers: dict[str, str],
+        variables: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        del query, headers, variables
+        raise ApiException("GraphQL failed", url="https://example.test/graphql")
+
+    monkeypatch.setattr(opower, "_async_post_graphql", fail_graphql)
+
+    with pytest.raises(ApiException) as exc_info:
+        await opower.async_get_realtime_usage_reads(_realtime_account())
+
+    assert exc_info.value.status == 424
+    assert "No meter asset ID returned" in (exc_info.value.response_text or "")
 
 
 def test_select_utility_accepts_name_and_class_name() -> None:

--- a/tests/test_opower.py
+++ b/tests/test_opower.py
@@ -1270,7 +1270,12 @@ def _realtime_account() -> Account:
 def _realtime_topology(*billing_accounts: dict[str, Any]) -> dict[str, Any]:
     """Build a GraphQL billing account topology response."""
     return {
-        "data": {"billingAccountsConnection": {"edges": [{"node": billing_account} for billing_account in billing_accounts]}}
+        "data": {
+            "billingAccountsConnection": {
+                "pageInfo": {"hasNextPage": False},
+                "edges": [{"node": billing_account} for billing_account in billing_accounts],
+            }
+        }
     }
 
 
@@ -1288,6 +1293,7 @@ def _realtime_billing_account(
         "accountNumber": account_number,
         "utilityId": account_number,
         "serviceAgreementsConnection": {
+            "pageInfo": {"hasNextPage": False},
             "edges": [
                 {
                     "node": {
@@ -1295,6 +1301,7 @@ def _realtime_billing_account(
                         "utilityId": service_agreement_utility_id,
                         "serviceType": "ELECTRICITY",
                         "servicePointsConnection": {
+                            "pageInfo": {"hasNextPage": False},
                             "edges": [
                                 {
                                     "node": {
@@ -1302,11 +1309,11 @@ def _realtime_billing_account(
                                         "serviceType": "ELECTRICITY",
                                     }
                                 }
-                            ]
+                            ],
                         },
                     }
                 }
-            ]
+            ],
         },
     }
 
@@ -1370,6 +1377,78 @@ def test_realtime_graphql_mapping_requires_service_agreement_identifier() -> Non
     )
 
     assert opower._realtime_graphql_mappings(account, topology) == []
+
+
+@pytest.mark.parametrize(
+    ("connection_name", "page_info"),
+    [
+        ("billing_accounts", {"hasNextPage": True}),
+        ("billing_accounts", None),
+        ("service_agreements", {"hasNextPage": True}),
+        ("service_agreements", None),
+        ("service_points", {"hasNextPage": True}),
+        ("service_points", None),
+    ],
+)
+def test_realtime_graphql_mapping_requires_complete_connections(
+    connection_name: str,
+    page_info: dict[str, bool] | None,
+) -> None:
+    """A truncated or malformed topology cannot establish a safe mapping."""
+    opower = _coned(_FakeSession({}))
+    account = _realtime_account()
+    topology = _realtime_topology(
+        _realtime_billing_account(
+            "selected-billing-account",
+            "selected-service-agreement",
+            service_agreement_utility_id=account.utility_account_id,
+        )
+    )
+    billing_accounts = topology["data"]["billingAccountsConnection"]
+    service_agreements = billing_accounts["edges"][0]["node"]["serviceAgreementsConnection"]
+    service_points = service_agreements["edges"][0]["node"]["servicePointsConnection"]
+    connection = {
+        "billing_accounts": billing_accounts,
+        "service_agreements": service_agreements,
+        "service_points": service_points,
+    }[connection_name]
+    if page_info is None:
+        connection.pop("pageInfo")
+    else:
+        connection["pageInfo"] = page_info
+
+    assert opower._realtime_graphql_mappings(account, topology) == []
+
+
+@pytest.mark.parametrize("duplicate_edge", ["service_agreement", "service_point"])
+def test_realtime_graphql_mapping_ignores_duplicate_edges(
+    duplicate_edge: str,
+) -> None:
+    """Duplicate edges for the same UUID do not make a mapping ambiguous."""
+    opower = _coned(_FakeSession({}))
+    account = _realtime_account()
+    topology = _realtime_topology(
+        _realtime_billing_account(
+            "selected-billing-account",
+            "selected-service-agreement",
+            service_agreement_utility_id=account.utility_account_id,
+        )
+    )
+    billing_account = topology["data"]["billingAccountsConnection"]["edges"][0]["node"]
+    service_agreement_edges = billing_account["serviceAgreementsConnection"]["edges"]
+    if duplicate_edge == "service_agreement":
+        service_agreement_edges.append(service_agreement_edges[0])
+    else:
+        service_point_edges = service_agreement_edges[0]["node"]["servicePointsConnection"]["edges"]
+        service_point_edges.append(service_point_edges[0])
+
+    assert opower._realtime_graphql_mappings(account, topology) == [
+        (
+            "urn:opower:v1:account:cned:uuid:selected-billing-account",
+            "selected-service-agreement",
+            "sp-selected-service-agreement",
+        )
+    ]
 
 
 @pytest.mark.asyncio
@@ -1495,10 +1574,110 @@ async def test_realtime_usage_reads_fall_back_when_graphql_mapping_is_ambiguous(
 
 
 @pytest.mark.asyncio
-async def test_realtime_usage_reads_fall_back_when_register_mapping_is_ambiguous(
+async def test_realtime_usage_reads_select_net_usage_register(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Multiple GraphQL registers use the compatibility REST API."""
+    """A NET_USAGE register is selected from a net-metered register set."""
+    opower = _coned(_FakeSession({}))
+    account = _realtime_account()
+    usage_variables: dict[str, Any] | None = None
+
+    async def fake_post_graphql(
+        query: str,
+        headers: dict[str, str],
+        variables: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        nonlocal usage_variables
+        del headers
+        if "WRTAMI_GetTopology" in query:
+            return _realtime_topology(
+                _realtime_billing_account(
+                    "selected-billing-account",
+                    "selected-service-agreement",
+                    service_agreement_utility_id=account.utility_account_id,
+                )
+            )
+        if "WRTAMI_GetRegisters" in query:
+            return _realtime_registers(
+                "KWH:DELIVERED",
+                "KWH:RECEIVED",
+                "KWH:NET_USAGE",
+            )
+        usage_variables = variables
+        return _realtime_usage(
+            {
+                "timeInterval": "2026-09-01T10:00:00-04:00/2026-09-01T10:15:00-04:00",
+                "measuredAmount": {"value": -0.4},
+            }
+        )
+
+    monkeypatch.setattr(opower, "_async_post_graphql", fake_post_graphql)
+
+    result = await opower.async_get_realtime_usage_reads(account)
+
+    assert [read.consumption for read in result] == [-0.4]
+    assert usage_variables is not None
+    assert usage_variables["registerId"] == "KWH:NET_USAGE"
+
+
+@pytest.mark.parametrize(
+    "graphql_reads",
+    [
+        (),
+        (
+            {
+                "timeInterval": "2026-09-01T10:00:00-04:00/2026-09-01T10:15:00-04:00",
+                "measuredAmount": None,
+            },
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_realtime_usage_reads_return_empty_for_valid_no_data(
+    monkeypatch: pytest.MonkeyPatch,
+    graphql_reads: tuple[dict[str, Any], ...],
+) -> None:
+    """A valid empty or null-only GraphQL stream does not use REST fallback."""
+    opower = _coned(_FakeSession({}))
+    account = _realtime_account()
+
+    async def fake_post_graphql(
+        query: str,
+        headers: dict[str, str],
+        variables: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        del headers, variables
+        if "WRTAMI_GetTopology" in query:
+            return _realtime_topology(
+                _realtime_billing_account(
+                    "selected-billing-account",
+                    "selected-service-agreement",
+                    service_agreement_utility_id=account.utility_account_id,
+                )
+            )
+        if "WRTAMI_GetRegisters" in query:
+            return _realtime_registers("opaque-register")
+        return _realtime_usage(*graphql_reads)
+
+    monkeypatch.setattr(opower, "_async_post_graphql", fake_post_graphql)
+
+    assert await opower.async_get_realtime_usage_reads(account) == []
+
+
+@pytest.mark.parametrize(
+    "register_ids",
+    [
+        ("opaque-register-1", "opaque-register-2"),
+        ("KWH:DELIVERED",),
+        ("KWH:RECEIVED",),
+    ],
+)
+@pytest.mark.asyncio
+async def test_realtime_usage_reads_fall_back_when_register_mapping_is_ambiguous(
+    monkeypatch: pytest.MonkeyPatch,
+    register_ids: tuple[str, ...],
+) -> None:
+    """Unidentified or directional GraphQL registers use compatibility REST."""
     session = _FakeSession(
         {
             "/meters/": {
@@ -1534,7 +1713,7 @@ async def test_realtime_usage_reads_fall_back_when_register_mapping_is_ambiguous
                 )
             )
         if "WRTAMI_GetRegisters" in query:
-            return _realtime_registers("net-register-1", "net-register-2")
+            return _realtime_registers(*register_ids)
         pytest.fail("GraphQL usage must not be queried for ambiguous registers")
 
     monkeypatch.setattr(opower, "_async_post_graphql", fake_post_graphql)

--- a/tests/test_opower.py
+++ b/tests/test_opower.py
@@ -1357,6 +1357,21 @@ def _realtime_usage(*reads: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def test_realtime_graphql_mapping_requires_service_agreement_identifier() -> None:
+    """A billing-account match alone cannot identify a service agreement."""
+    opower = _coned(_FakeSession({}))
+    account = _realtime_account()
+    topology = _realtime_topology(
+        _realtime_billing_account(
+            account.uuid,
+            "unmatched-service-agreement",
+            account_number=account.utility_account_id,
+        )
+    )
+
+    assert opower._realtime_graphql_mappings(account, topology) == []
+
+
 @pytest.mark.asyncio
 async def test_realtime_usage_reads_use_graphql_net_usage_and_cache_discovery(
     monkeypatch: pytest.MonkeyPatch,
@@ -1456,8 +1471,16 @@ async def test_realtime_usage_reads_fall_back_when_graphql_mapping_is_ambiguous(
         del query, headers, variables
         topology_calls += 1
         return _realtime_topology(
-            _realtime_billing_account("billing-1", "service-agreement-1"),
-            _realtime_billing_account("billing-2", "service-agreement-2"),
+            _realtime_billing_account(
+                "billing-1",
+                "service-agreement-1",
+                service_agreement_utility_id=account.utility_account_id,
+            ),
+            _realtime_billing_account(
+                "billing-2",
+                "service-agreement-2",
+                service_agreement_utility_id=account.utility_account_id,
+            ),
         )
 
     monkeypatch.setattr(opower, "_async_post_graphql", fake_post_graphql)
@@ -1468,6 +1491,60 @@ async def test_realtime_usage_reads_fall_back_when_graphql_mapping_is_ambiguous(
     assert [read.consumption for read in first] == [0.4]
     assert second == first
     assert topology_calls == 1
+    assert [request["method"] for request in session.requests] == ["GET", "GET", "GET"]
+
+
+@pytest.mark.asyncio
+async def test_realtime_usage_reads_fall_back_when_register_mapping_is_ambiguous(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Multiple GraphQL registers use the compatibility REST API."""
+    session = _FakeSession(
+        {
+            "/meters/": {
+                "reads": [
+                    {
+                        "startTime": "2026-09-01T10:00:00-04:00",
+                        "endTime": "2026-09-01T10:15:00-04:00",
+                        "value": 0.4,
+                    }
+                ]
+            },
+            "/meters": {"meters_ids": ["KWH:NET_USAGE"]},
+        }
+    )
+    opower = _coned(session)
+    account = _realtime_account()
+    graphql_calls = 0
+
+    async def fake_post_graphql(
+        query: str,
+        headers: dict[str, str],
+        variables: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        nonlocal graphql_calls
+        del headers, variables
+        graphql_calls += 1
+        if "WRTAMI_GetTopology" in query:
+            return _realtime_topology(
+                _realtime_billing_account(
+                    "selected-billing-account",
+                    "selected-service-agreement",
+                    service_agreement_utility_id=account.utility_account_id,
+                )
+            )
+        if "WRTAMI_GetRegisters" in query:
+            return _realtime_registers("net-register-1", "net-register-2")
+        pytest.fail("GraphQL usage must not be queried for ambiguous registers")
+
+    monkeypatch.setattr(opower, "_async_post_graphql", fake_post_graphql)
+
+    first = await opower.async_get_realtime_usage_reads(account)
+    second = await opower.async_get_realtime_usage_reads(account)
+
+    assert [read.consumption for read in first] == [0.4]
+    assert second == first
+    assert graphql_calls == 2
     assert [request["method"] for request in session.requests] == ["GET", "GET", "GET"]
 
 


### PR DESCRIPTION
Fixes #180

ConEd's legacy realtime meter endpoint now returns HTTP 424 with `No meter asset ID returned` for the validated account. This changes realtime usage reads to use the portal's GraphQL WRTAMI flow first while retaining the existing REST implementation as a compatibility fallback when GraphQL discovery is unavailable, ambiguous, or fails.

The GraphQL path scopes discovery to the requested account, requires an exact service-agreement identifier match and an unambiguous service point/register/stream, caches stable register metadata, and requests `KWH` `NET_USAGE` with `onlyUnverifiedStreams: true`. Negative net usage is preserved and null measured amounts are skipped.

The public Opower GraphQL schema officially documents the billing account, service agreement, service point identifiers, and the `NET_USAGE` enum. The WRTAMI-specific fields and arguments used here are not present in that public schema; they are observed ConEd portal behavior from September 1, 2026. Oracle's published REST Swagger does not document the legacy `cws-real-time-ami` route either.

Sanitized live validation on September 1, 2026 found:
- Legacy realtime REST: HTTP 424, `No meter asset ID returned`
- GraphQL WRTAMI: 92 non-null 15-minute reads, latest 49.4 minutes old
- DataBrowser quarter-hour data: latest 619.4 minutes old
- 54 overlapping GraphQL/DataBrowser reads matched exactly, maximum delta 0.0
- The implemented public client path returned 92 15-minute reads in three GraphQL calls, with the latest interval 53.5 minutes old

This is consistent with the independent ConEd portal HAR analysis in https://github.com/dasl-/pitools/pull/15, which reports roughly 50-minute GraphQL latency compared with about one hour for legacy REST and 13 hours for DataBrowser.

Bill reads, costs, historical DataBrowser reads, forecasts, CLI behavior, and dependencies are unchanged.
